### PR TITLE
Make postSwap return the swap ID

### DIFF
--- a/src/cnd.ts
+++ b/src/cnd.ts
@@ -211,13 +211,15 @@ export class Cnd {
     return info.listen_addresses;
   }
 
-  public postSwap(swap: SwapRequest): Promise<string> {
-    return axios.post(
-      this.rootUrl()
-        .path("swaps/rfc003")
-        .toString(),
-      swap
-    );
+  public async postSwap(swap: SwapRequest): Promise<string> {
+    return axios
+      .post(
+        this.rootUrl()
+          .path("swaps/rfc003")
+          .toString(),
+        swap
+      )
+      .then(res => res.data.id);
   }
 
   public async getSwaps(): Promise<EmbeddedRepresentationSubEntity[]> {


### PR DESCRIPTION
The ID is what is already returned by cnd, we just were ignoring it in the SDK.