### PR TITLE
Fix json2ts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- `postinstall` task.
+
 ## [0.5.0] - 2019-11-04
 ### Added
 - `Swap.getEntity()` to get details of the swap.

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "check": "tsc --noEmit && tslint -p . && prettier --check '**/*.{ts,js,json,yml}'",
     "rebuild": "rimraf dist/ && tsc",
-    "postinstall": "mkdir -p ./gen && json2ts -i ./siren.schema.json -o ./gen/siren.d.ts && prettier --write ./gen/siren.d.ts",
+    "postinstall": "mkdir -p ./gen && yarn json2ts -i ./siren.schema.json -o ./gen/siren.d.ts && yarn prettier --write ./gen/siren.d.ts",
     "fix": "tslint -p . --fix && prettier --write '**/*.{ts,js,json,yml}'",
     "test": "jest"
   },


### PR DESCRIPTION
To fix `0.5.0`:
This error appears when doing `yarn install` in create-comit-app example after upgrading to `comit-sdk:0.5.0`.

```
error /Users/froyer/src/create-comit-app/new_project/examples/erc20_btc/node_modules/comit-sdk: Command failed.
Exit code: 127
Command: mkdir -p ./gen && json2ts -i ./siren.schema.json -o ./gen/siren.d.ts && prettier --write ./gen/siren.d.ts
Arguments: 
```