### PR TITLE
Pack dist/ folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 node_modules/
-dist/
 
 .idea/
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Pack dist files when publishing.
 
 ## [0.5.3] - 2019-11-05
 ### Fixed


### PR DESCRIPTION
Files ignored by git are not included by `yarn publish`.

Moreover, we fixed the scripts so that we do expect to generate a dist folder as part of normal development.