### PR TITLE
Return tx-id instead of tx-hash to be able to request via REST-API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Return the tx-id instead of the tx-hash for Bitcoin because it is the canonical way of identifying a transaction.
+
 ## [0.5.6] - 2019-11-05
 
 ### Fixed

--- a/src/bitcoinWallet.ts
+++ b/src/bitcoinWallet.ts
@@ -111,7 +111,7 @@ export class BitcoinWallet {
     });
     await this.pool.broadcast(transaction);
 
-    return transaction.hash("hex");
+    return transaction.txid();
   }
 
   public async broadcastTransaction(
@@ -124,7 +124,7 @@ export class BitcoinWallet {
 
     await this.pool.broadcast(transaction);
 
-    return transaction.hash("hex");
+    return transaction.txid();
   }
 
   public getFee() {


### PR DESCRIPTION
For difference check:
https://bitcoin.stackexchange.com/questions/77699/whats-the-difference-between-txid-and-hash-getrawtransaction-bitcoind
In order to request the TX from bitcoind REST API we need tx-id.