### PR TITLE
Remove irrelevant documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,5 +34,3 @@ The SDK includes two Javascript wallets:
 * Bitcoin wallet based on [bcoin](https://github.com/bcoin-org/bcoin)
 * Ethereum wallet based on [ethers.js](https://github.com/ethers-io/ethers.js/)
 
-When starting an environment using the `start-env` command of [create-comit-app](https://github.com/comit-network/create-comit-app) an `.env` file is created that is read by an application using the SDK. 
-The wallets are used to request balances and sending transactions.


### PR DESCRIPTION
The SDK can be used in a variety of ways, with examples/projects using create-comit-app being only one of them. In order to not confuse developers in what they can do with the SDK, we should not mention implementation details of how create-comit-app works here.