### PR TITLE
Make expiries optional

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 node_modules/
 
+dist/
+
 .idea/
 
 # This is a library

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,5 @@
 node_modules/
 
-dist/
-
 .idea/
 
 # This is a library

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Make alpha and beta expiries optional in `SwapRequest`.
+
 ## [0.6.0] - 2019-11-25
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@types/express": "^4.17.2",
     "@types/jest": "^24.0.18",
     "@types/moment": "^2.13.0",
+    "@types/node": "^12.12.12",
     "@types/urijs": "^1.19.3",
     "jest": "^24.9.0",
     "nock": "^11.3.4",

--- a/src/cnd.ts
+++ b/src/cnd.ts
@@ -32,8 +32,8 @@ export interface SwapRequest {
   alpha_asset: Asset;
   beta_ledger: Ledger;
   beta_asset: Asset;
-  alpha_expiry: number;
-  beta_expiry: number;
+  alpha_expiry?: number;
+  beta_expiry?: number;
   alpha_ledger_refund_identity?: string;
   beta_ledger_redeem_identity?: string;
   peer: Peer;


### PR DESCRIPTION
`cnd` has now been able to derive expiries for you [for a while](https://github.com/comit-network/comit-rs/pull/1602). Mind you this is still not released, but it will work with `comit-rs@master`.

Fixes #52.

---

As a side note, it is extremely painful to test this using `create-comit-app`.