### PR TITLE
Improve negotiation protocol by allowing swap retrieval by id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Improve negotiation protocol to allow maker to identify a taken order by swap id.
+
 ## [0.7.0] - 2019-11-27
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Improve negotiation protocol to allow maker to identify a taken order by swap id.
 
+### Fixed
+- Auto-accept introduced with negotiation protocol.
+
 ## [0.7.0] - 2019-11-27
 
 ### Changed

--- a/src/comitClient.ts
+++ b/src/comitClient.ts
@@ -54,15 +54,20 @@ export class ComitClient {
 
   public async getOngoingSwaps(): Promise<Swap[]> {
     const swaps = await this.cnd.getSwaps();
-
     return swaps
-      .filter((swap: EmbeddedRepresentationSubEntity) => {
-        return (
-          swap.actions &&
-          !!swap.actions.find((action: Action) => {
-            return action.name === "fund" || action.name === "redeem";
-          })
-        );
+      .filter((swap: SwapSubEntity) => {
+        if (swap.properties && swap.properties.status === "IN_PROGRESS") {
+          if (swap.actions && swap.actions.length !== 0) {
+            return !!swap.actions.find((action: Action) => {
+              return action.name === "fund" || action.name === "redeem";
+            });
+          } else if (swap.properties.role === "Bob") {
+            // If there is no action but it is in progress then it is
+            // Accepted and pending for Alice to fund
+            return true;
+          }
+        }
+        return false;
       })
       .map(swap => this.newSwap(swap));
   }

--- a/src/negotiation/execution_params.spec.ts
+++ b/src/negotiation/execution_params.spec.ts
@@ -1,5 +1,5 @@
 import moment = require("moment");
-import { ExecutionParams, validateExecutionParams } from "./execution_params";
+import { ExecutionParams, isValidExecutionParams } from "./execution_params";
 
 const defaultExecutionParams = () => {
   return {
@@ -20,7 +20,7 @@ describe("Taker Negotiator", () => {
   it("Validates mainnet execution parameters", () => {
     const executionParams: ExecutionParams = { ...defaultExecutionParams() };
 
-    expect(validateExecutionParams(executionParams)).toBeTruthy();
+    expect(isValidExecutionParams(executionParams)).toBeTruthy();
   });
 
   it("Validates test execution parameters", () => {
@@ -34,7 +34,7 @@ describe("Taker Negotiator", () => {
       }
     };
 
-    expect(validateExecutionParams(executionParams)).toBeTruthy();
+    expect(isValidExecutionParams(executionParams)).toBeTruthy();
   });
 
   it("Invalidates mainnet execution parameters due to expiry length", () => {
@@ -44,7 +44,7 @@ describe("Taker Negotiator", () => {
       beta_expiry: moment().unix() + 1 * 60 * 60
     };
 
-    expect(validateExecutionParams(executionParams)).toBeFalsy();
+    expect(isValidExecutionParams(executionParams)).toBeFalsy();
   });
 
   it("Invalidates mainnet execution parameters due to expiry order", () => {
@@ -54,7 +54,7 @@ describe("Taker Negotiator", () => {
       beta_expiry: moment().unix() + 72 * 60 * 60
     };
 
-    expect(validateExecutionParams(executionParams)).toBeFalsy();
+    expect(isValidExecutionParams(executionParams)).toBeFalsy();
   });
 
   it("Invalidates test execution parameters due to expiry", () => {
@@ -68,7 +68,7 @@ describe("Taker Negotiator", () => {
       }
     };
 
-    expect(validateExecutionParams(executionParams)).toBeFalsy();
+    expect(isValidExecutionParams(executionParams)).toBeFalsy();
   });
 
   it("Invalidates mixed network execution parameters", () => {
@@ -80,6 +80,6 @@ describe("Taker Negotiator", () => {
       }
     };
 
-    expect(validateExecutionParams(executionParams)).toBeFalsy();
+    expect(isValidExecutionParams(executionParams)).toBeFalsy();
   });
 });

--- a/src/negotiation/execution_params.ts
+++ b/src/negotiation/execution_params.ts
@@ -24,7 +24,7 @@ interface LedgerParams {
   };
 }
 
-export function validateExecutionParams(
+export function isValidExecutionParams(
   executionParams: ExecutionParams
 ): boolean {
   const now = moment().unix();

--- a/src/negotiation/maker_negotiator.ts
+++ b/src/negotiation/maker_negotiator.ts
@@ -21,6 +21,12 @@ export class MakerNegotiator {
     this.tryParams = tryParams;
   }
 
+  public addOrder(order: Order) {
+    this.ordersByTradingPair[order.tradingPair] = order;
+    this.ordersById[order.id] = order;
+  }
+
+  // Below are methods related to the negotiation protocol
   public getOrderByTradingPair(tradingPair: string): Order | undefined {
     return this.ordersByTradingPair[tradingPair];
   }
@@ -43,11 +49,7 @@ export class MakerNegotiator {
     })();
     return this.executionParams;
   }
-
-  public addOrder(order: Order) {
-    this.ordersByTradingPair[order.tradingPair] = order;
-    this.ordersById[order.id] = order;
-  }
+  // End of methods related to the negotiation protocol
 
   private async tryAcceptSwap(
     order: Order,

--- a/src/negotiation/maker_negotiator.ts
+++ b/src/negotiation/maker_negotiator.ts
@@ -2,7 +2,7 @@ import express from "express";
 import { ComitClient } from "../comitClient";
 import { sleep, timeoutPromise, TryParams } from "../timeout_promise";
 import { ExecutionParams } from "./execution_params";
-import { Order } from "./order";
+import { Order, orderSwapMatchesForMaker } from "./order";
 
 export class MakerNegotiator {
   private ordersByTradingPair: { [tradingPair: string]: Order } = {};
@@ -35,43 +35,61 @@ export class MakerNegotiator {
     return this.ordersById[orderId];
   }
 
-  public acceptOrder(
-    // @ts-ignore
-    order: Order
-  ): ExecutionParams | undefined {
+  public getExecutionParams(): ExecutionParams {
+    return this.executionParams;
+  }
+
+  public acceptOrder(swapId: string, order: Order) {
     // Fire the auto-accept of the order in the background
     (async () => {
       try {
-        await this.tryAcceptSwap(order, this.tryParams);
+        await this.tryAcceptSwap(swapId, order, this.tryParams);
       } catch (error) {
         console.log("Could not accept the swap");
       }
     })();
-    return this.executionParams;
   }
   // End of methods related to the negotiation protocol
 
-  private async tryAcceptSwap(
+  private tryAcceptSwap(
+    swapId: string,
     order: Order,
     { maxTimeoutSecs, tryIntervalSecs }: TryParams
   ) {
     return timeoutPromise(
       maxTimeoutSecs * 1000,
-      this.acceptSwap(order, tryIntervalSecs)
+      this.acceptSwap(swapId, order, tryIntervalSecs)
     );
   }
 
-  private async acceptSwap(order: Order, tryIntervalSecs: number) {
+  private async acceptSwap(
+    swapId: string,
+    order: Order,
+    tryIntervalSecs: number
+  ) {
     while (true) {
       await sleep(tryIntervalSecs * 1000);
 
-      const swap = await this.comitClient.retrieveSwapByOrder(order);
+      const swap = await this.comitClient.retrieveSwapById(swapId);
 
       if (!swap) {
         continue;
       }
 
-      return swap.accept(this.tryParams);
+      const swapDetails = await swap.fetchDetails();
+
+      if (
+        swapDetails.properties &&
+        orderSwapMatchesForMaker(order, swapDetails.properties)
+      ) {
+        return swap.accept(this.tryParams);
+      } else {
+        console.log(
+          "Swap request was malformed, giving up on trying to accept"
+        );
+        // The swap request is not as expected, no need to try again
+        break;
+      }
     }
   }
 }
@@ -86,6 +104,8 @@ export class MakerHttpApi {
   public listen(port: number) {
     const app = express();
 
+    app.use(express.json());
+
     app.get("/", (_, res) =>
       res.send("MakerNegotiator's Negotiation Service is up and running!")
     );
@@ -99,12 +119,20 @@ export class MakerHttpApi {
       }
     });
 
+    app.get("/orders/:tradingPair/:orderId/executionParams", async (_, res) => {
+      res.send(this.maker.getExecutionParams());
+    });
+
     app.post("/orders/:tradingPair/:orderId/accept", async (req, res) => {
       const order = this.maker.getOrderById(req.params.orderId);
+      const body = req.body;
+
       if (!order || req.params.tradingPair !== order.tradingPair) {
         res.status(404).send("Order not found");
+      } else if (!body || !body.swapId) {
+        res.status(400).send("swapId missing from payload");
       } else {
-        res.send(this.maker.acceptOrder(order));
+        res.send(this.maker.acceptOrder(body.swapId, order));
       }
     });
 


### PR DESCRIPTION
Implement this protocol negotiation improvement:

```
// This (finding swap using order details)
// should be simplified by retrieving via order id
// Or by doing an extra round trip:
// Taker -->(ask exec params)--> Maker
// Taker <--(exec params)<-- Maker
// Taker -->(send swap req)--> Taker cnd
// Taker -->(accept order, inc. swap id)--> Maker
// Maker -->(retrieve. check and accept with swap id)--> Maker cnd
// In any case, a matching logic to verify that the taker sent
// the correct parameter needs to happen but this verification
// step may not be done in the ComitClient
```

Also, fix auto-accept.