### PR TITLE
Add `createActor` function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- New function `createActor` to setup an actor's `comitClient`, retrieve its `ID` and bundle it with btc/eth wallets
+
 ## [0.7.1] - 2019-11-29
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- New function `createActor` to setup an actor's `comitClient`, retrieve its `ID` and bundle it with btc/eth wallets
+- New function `createActor` to setup an actor's `comitClient`, retrieve its `ID` and bundle it with btc/eth wallets.
 
 ## [0.7.1] - 2019-11-29
 

--- a/src/actor.ts
+++ b/src/actor.ts
@@ -1,0 +1,37 @@
+import { BitcoinWallet } from "./bitcoinWallet";
+import { Cnd } from "./cnd";
+import { ComitClient } from "./comitClient";
+import { EthereumWallet } from "./ethereumWallet";
+
+export interface Actor {
+  name: string;
+  comitClient: ComitClient;
+  peerId: string;
+  addressHint: string;
+  bitcoinWallet: BitcoinWallet;
+  ethereumWallet: EthereumWallet;
+}
+
+export async function createActor(
+  bitcoinWallet: BitcoinWallet,
+  ethereumWallet: EthereumWallet,
+  cndUrl: string,
+  name: string
+): Promise<Actor> {
+  const cnd = new Cnd(cndUrl!);
+  const peerId = await cnd.getPeerId();
+  const addressHint = await cnd
+    .getPeerListenAddresses()
+    .then(addresses => addresses[0]);
+
+  const comitClient = new ComitClient(bitcoinWallet, ethereumWallet, cnd);
+
+  return {
+    name,
+    comitClient,
+    peerId,
+    addressHint,
+    bitcoinWallet,
+    ethereumWallet
+  };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,8 @@ export {
   SwapRequest
 } from "./cnd";
 
+export { Actor, createActor } from "./actor";
+
 export { BitcoinWallet } from "./bitcoinWallet";
 export * from "./siren";
 

--- a/src/siren.ts
+++ b/src/siren.ts
@@ -81,7 +81,8 @@ export type RelValue =
       | "via"
       | "webmention"
       | "working-copy"
-      | "working-copy-of");
+      | "working-copy-of"
+    );
 /**
  * Defines media type of the linked resource, per Web Linking (RFC5988). For the syntax, see RFC2045 (section 5.1), RFC4288 (section 4.2), RFC6838 (section 4.2)
  */

--- a/src/siren.ts
+++ b/src/siren.ts
@@ -81,8 +81,7 @@ export type RelValue =
       | "via"
       | "webmention"
       | "working-copy"
-      | "working-copy-of"
-    );
+      | "working-copy-of");
 /**
  * Defines media type of the linked resource, per Web Linking (RFC5988). For the syntax, see RFC2045 (section 5.1), RFC4288 (section 4.2), RFC6838 (section 4.2)
  */


### PR DESCRIPTION
Resolves #61 (next step is updating the examples which can only be done once this is merged and released)


Note: I opted for passing in the wallets from the outside so that the developer can overwrite them if wanted. 

How to use (e.g. within the examples):

```javascript
    const bitcoinWallet = await BitcoinWallet.newInstance(
        "regtest",
        process.env.BITCOIN_P2P_URI!,
        process.env[`BITCOIN_HD_KEY_${index}`]!
    );

    const ethereumWallet = new EthereumWallet(
        process.env.ETHEREUM_NODE_HTTP_URL!,
        process.env[`ETHEREUM_KEY_${index}`]!
    );

    let taker = startActor(bitcoinWallet, ethereumWallet, process.env[`HTTP_URL_CND_${index}`]!, "taker");
```

