### PR TITLE
treat conversion of Bitcoin different than Ethereum in from Nominal

### DIFF
--- a/src/negotiation/order.spec.ts
+++ b/src/negotiation/order.spec.ts
@@ -1,6 +1,8 @@
+import { BigNumber } from "ethers/utils";
 import { Asset } from "../cnd";
 import {
   assetOrderToSwap,
+  fromNominal,
   isNative,
   OrderAsset,
   orderSwapAssetMatchesForMaker,
@@ -224,5 +226,17 @@ describe("Payload module", () => {
     };
     const actualSwapAsset = assetOrderToSwap(orderAsset);
     expect(actualSwapAsset).toStrictEqual(expectedSwapAsset);
+  });
+
+  it("should be able to convert fractions of Bitcoin", () => {
+    const converted = fromNominal("bitcoin", "0.1");
+    const expected = new BigNumber("10000000");
+    expect(converted).toStrictEqual(expected);
+  });
+
+  it("should be able to convert Bitcoin", () => {
+    const converted = fromNominal("bitcoin", "100");
+    const expected = new BigNumber("10000000000");
+    expect(converted).toStrictEqual(expected);
   });
 });

--- a/src/negotiation/order.ts
+++ b/src/negotiation/order.ts
@@ -124,30 +124,31 @@ function areAmountsEqual(
   return amount.eq(new BigNumber(unitAmount));
 }
 
-function fromNominal(
+export function fromNominal(
   asset: string,
   nominalAmount: string,
   token?: Token
 ): BigNumber | undefined {
-  const nominal = new BigNumber(nominalAmount);
-
-  let decimals = 0;
-  switch (asset) {
-    case "bitcoin": {
-      decimals = 8;
-      break;
-    }
-    case "ether": {
-      decimals = 18;
-      break;
-    }
-    default: {
-      if (token) {
-        decimals = token.decimals;
-      } else {
-        return undefined;
+  if (asset === "bitcoin") {
+    const nominal = parseFloat(nominalAmount);
+    const actual = nominal * 100000000;
+    return new BigNumber(actual);
+  } else {
+    const nominal = new BigNumber(nominalAmount);
+    let decimals = 0;
+    switch (asset) {
+      case "ether": {
+        decimals = 18;
+        break;
+      }
+      default: {
+        if (token) {
+          decimals = token.decimals;
+        } else {
+          return undefined;
+        }
       }
     }
+    return nominal.mul(new BigNumber(10).pow(decimals));
   }
-  return nominal.mul(new BigNumber(10).pow(decimals));
 }

--- a/src/siren.ts
+++ b/src/siren.ts
@@ -81,7 +81,8 @@ export type RelValue =
       | "via"
       | "webmention"
       | "working-copy"
-      | "working-copy-of");
+      | "working-copy-of"
+    );
 /**
  * Defines media type of the linked resource, per Web Linking (RFC5988). For the syntax, see RFC2045 (section 5.1), RFC4288 (section 4.2), RFC6838 (section 4.2)
  */

--- a/src/siren.ts
+++ b/src/siren.ts
@@ -81,8 +81,7 @@ export type RelValue =
       | "via"
       | "webmention"
       | "working-copy"
-      | "working-copy-of"
-    );
+      | "working-copy-of");
 /**
  * Defines media type of the linked resource, per Web Linking (RFC5988). For the syntax, see RFC2045 (section 5.1), RFC4288 (section 4.2), RFC6838 (section 4.2)
  */


### PR DESCRIPTION
Bitcoin has to allow a fraction.
It should not use Ethers BigNumber for the conversion.