### PR TITLE
Refactor negotiation protocol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Chang in the negotiation protocol. Simplified interfaces and renamed 
+
 ## [0.7.2] - 2019-12-05
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
-- Chang in the negotiation protocol. Simplified interfaces and renamed 
+- Refactor negotiation protocol: simplified and renamed interfaces. Make getOrder/takeOrder more explicit for the client
 
 ## [0.7.2] - 2019-12-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
-- Refactor negotiation protocol: simplified and renamed interfaces. Make getOrder/takeOrder more explicit for the client
+- **Breaking change** of the negotiation protocol: simplified and renamed interfaces. Make getOrder/takeOrder more explicit for the client
 
 ## [0.7.2] - 2019-12-05
 

--- a/src/negotiation/maker_negotiator.ts
+++ b/src/negotiation/maker_negotiator.ts
@@ -39,7 +39,7 @@ export class MakerNegotiator {
     return this.executionParams;
   }
 
-  public acceptOrder(swapId: string, order: Order) {
+  public takeOrder(swapId: string, order: Order) {
     // Fire the auto-accept of the order in the background
     (async () => {
       try {
@@ -123,7 +123,7 @@ export class MakerHttpApi {
       res.send(this.maker.getExecutionParams());
     });
 
-    app.post("/orders/:tradingPair/:orderId/accept", async (req, res) => {
+    app.post("/orders/:tradingPair/:orderId/take", async (req, res) => {
       const order = this.maker.getOrderById(req.params.orderId);
       const body = req.body;
 
@@ -132,7 +132,7 @@ export class MakerHttpApi {
       } else if (!body || !body.swapId) {
         res.status(400).send("swapId missing from payload");
       } else {
-        res.send(this.maker.acceptOrder(body.swapId, order));
+        res.send(this.maker.takeOrder(body.swapId, order));
       }
     });
 

--- a/src/negotiation/taker_negotiator.ts
+++ b/src/negotiation/taker_negotiator.ts
@@ -52,21 +52,14 @@ export class TakerNegotiator {
     this.comitClient = comitClient;
   }
 
-  public async negotiateAndInitiateSwap(
+  public async getOrderByTradingPair(
     makerNegotiator: MakerClient,
-    tradingPair: string,
-    isOrderAcceptable: (order: Order) => boolean
-  ): Promise<{ order: Order; swap?: Swap }> {
-    const order = await this.negotiate(makerNegotiator, tradingPair);
-
-    if (order && isOrderAcceptable(order)) {
-      const swap = await this.initiateSwap(makerNegotiator, order);
-      return { swap, order };
-    }
-    return { order };
+    tradingPair: string
+  ): Promise<Order> {
+    return makerNegotiator.getOrderByTradingPair(tradingPair);
   }
 
-  public async initiateSwap(
+  public async takeOrder(
     makerNegotiator: MakerClient,
     order: Order
   ): Promise<Swap | undefined> {
@@ -81,17 +74,10 @@ export class TakerNegotiator {
 
         const swapDetails = await swapHandle.fetchDetails();
         const swapId = swapDetails.properties!.id;
-        await makerNegotiator.acceptOrder(order, swapId);
+        await makerNegotiator.takeOrder(order, swapId);
         return swapHandle;
       }
     }
-  }
-
-  public async negotiate(
-    makerNegotiator: MakerClient,
-    tradingPair: string
-  ): Promise<Order> {
-    return makerNegotiator.getOrderByTradingPair(tradingPair);
   }
 }
 
@@ -114,9 +100,9 @@ export class MakerClient {
     return response.data;
   }
 
-  public async acceptOrder(order: Order, swapId: string) {
+  public async takeOrder(order: Order, swapId: string) {
     const response = await axios.post(
-      `${this.makerUrl}orders/${order.tradingPair}/${order.id}/accept`,
+      `${this.makerUrl}orders/${order.tradingPair}/${order.id}/take`,
       { swapId }
     );
     return response.data;

--- a/src/negotiation/taker_negotiator.ts
+++ b/src/negotiation/taker_negotiator.ts
@@ -47,37 +47,40 @@ export class TakerNegotiator {
   }
 
   private readonly comitClient: ComitClient;
+  private readonly makerNegotiator: MakerClient;
 
-  constructor(comitClient: ComitClient) {
+  constructor(comitClient: ComitClient, makerNegotiator: MakerClient) {
     this.comitClient = comitClient;
+    this.makerNegotiator = makerNegotiator;
   }
 
-  public async getOrderByTradingPair(
-    makerNegotiator: MakerClient,
-    tradingPair: string
-  ): Promise<Order> {
-    return makerNegotiator.getOrderByTradingPair(tradingPair);
+  public async getOrderByTradingPair(tradingPair: string): Promise<Order> {
+    return this.makerNegotiator.getOrderByTradingPair(tradingPair);
   }
 
-  public async takeOrder(
-    makerNegotiator: MakerClient,
-    order: Order
-  ): Promise<Swap | undefined> {
-    const executionParams = await makerNegotiator.getExecutionParams(order);
-    if (executionParams && isValidExecutionParams(executionParams)) {
-      const swapRequest = TakerNegotiator.newSwapRequest(
-        order,
-        executionParams
-      );
-      if (swapRequest) {
-        const swapHandle = await this.comitClient.sendSwap(swapRequest);
-
-        const swapDetails = await swapHandle.fetchDetails();
-        const swapId = swapDetails.properties!.id;
-        await makerNegotiator.takeOrder(order, swapId);
-        return swapHandle;
-      }
+  public async takeOrder(order: Order): Promise<Swap | undefined> {
+    const executionParams = await this.makerNegotiator.getExecutionParams(
+      order
+    );
+    if (!executionParams) {
+      return;
     }
+
+    if (!isValidExecutionParams(executionParams)) {
+      return;
+    }
+
+    const swapRequest = TakerNegotiator.newSwapRequest(order, executionParams);
+    if (!swapRequest) {
+      return;
+    }
+
+    const swapHandle = await this.comitClient.sendSwap(swapRequest);
+
+    const swapDetails = await swapHandle.fetchDetails();
+    const swapId = swapDetails.properties!.id;
+    await this.makerNegotiator.takeOrder(order, swapId);
+    return swapHandle;
   }
 }
 


### PR DESCRIPTION
This PR introduces some breaking changes to the negotiation protocol:

* `TakerNegotiator` now takes both `comitClient` and `makerNegotiator` in the constructor instead of being passed in every function
* Removed `negotiateAndInitiateSwap` function to make taking orders more implicit for the taker. This simplifies the logic on the application side.
* Renamed `acceptOrder` to `takeOrder` for the taker