### PR TITLE
Add license field

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "types": "dist/src/index.d.ts",
   "repository": "git@github.com:comit-network/comit-js-sdk.git",
   "author": "CoBloX developers <team@coblox.tech>",
+  "license": "Apache-2.0",
   "scripts": {
     "prepare": "tsc",
     "fix": "tslint -p . --fix && prettier --write '**/*.{ts,js,json,yml}'",


### PR DESCRIPTION
`npm` emits:

	npm WARN comit-sdk@0.9.1 No license field.

We have a LICENSE file, add a field to package.json with the same
information.