### PR TITLE
No need to initialise a `MakerClient` anymore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- `Breaking API Change`: No need to initialise a `MakerClient` anymore, `TakerNegotiator`'s constructor directly accept URL to Maker.
+
 ## [0.9.1] - 2020-01-21
 
 ### Fixed

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,6 +39,6 @@ export {
   NetworkType
 } from "./negotiation/execution_params";
 export { MakerNegotiator, MakerHttpApi } from "./negotiation/maker_negotiator";
-export { TakerNegotiator, MakerClient } from "./negotiation/taker_negotiator";
+export { TakerNegotiator } from "./negotiation/taker_negotiator";
 
 export { TryParams } from "./timeout_promise";

--- a/src/negotiation/taker_negotiator.ts
+++ b/src/negotiation/taker_negotiator.ts
@@ -49,9 +49,9 @@ export class TakerNegotiator {
   private readonly comitClient: ComitClient;
   private readonly makerNegotiator: MakerClient;
 
-  constructor(comitClient: ComitClient, makerNegotiator: MakerClient) {
+  constructor(comitClient: ComitClient, makerUrl: string) {
     this.comitClient = comitClient;
-    this.makerNegotiator = makerNegotiator;
+    this.makerNegotiator = new MakerClient(makerUrl);
   }
 
   public async getOrderByTradingPair(tradingPair: string): Promise<Order> {
@@ -84,7 +84,7 @@ export class TakerNegotiator {
   }
 }
 
-export class MakerClient {
+class MakerClient {
   private readonly makerUrl: string;
 
   constructor(makerUrl: string) {


### PR DESCRIPTION
`TakerNegotiator`'s constructor directly accept URL to Maker.

See https://github.com/comit-network/comit-js-sdk/issues/90