### PR TITLE
Update Typedoc markdown generation command

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <a href="https://comit.network">
-<img src="logo.svg" height="120px">
+  <img src="logo.svg" height="120px" />
 </a>
 
 ---

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "test": "tsc --noEmit && tslint -p . && prettier --check '**/*.{ts,js,json,yml}' && jest",
     "docs:clean": "rm -rf docs/",
     "docs": "npm run docs:clean && typedoc --plugin none && open docs/index.html",
-    "docs:md": "npm run docs:clean && typedoc --plugin typedoc-plugin-markdown"
+    "docs:md": "npm run docs:clean && typedoc --plugin typedoc-plugin-markdown --hideBreadcrumbs --theme docusaurus2"
   },
   "dependencies": {
     "axios": "^0.19.0",


### PR DESCRIPTION
Minor changes around API doc generation. Specifically:

- Specify additional flags for Typedoc markdown generation
- Fix broken img tag (Please remember to close `<img />` tags, orphaned HTML tags will break some Markdown compilers.)
