### PR TITLE
Add Typedoc artifacts to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ node_modules/
 
 docs/
 dist/
+website/
 
 # This is a library
 yarn.lock

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "test": "tsc --noEmit && tslint -p . && prettier --check '**/*.{ts,js,json,yml}' && jest",
     "docs:clean": "rm -rf docs/",
     "docs": "npm run docs:clean && typedoc --plugin none && open docs/index.html",
-    "docs:md": "npm run docs:clean && typedoc --plugin typedoc-plugin-markdown --hideBreadcrumbs --theme docusaurus2"
+    "docs:md": "npm run docs:clean && typedoc --plugin typedoc-plugin-markdown --theme docusaurus2"
   },
   "dependencies": {
     "axios": "^0.19.0",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "test": "tsc --noEmit && tslint -p . && prettier --check '**/*.{ts,js,json,yml}' && jest",
     "docs:clean": "rm -rf docs/",
     "docs": "npm run docs:clean && typedoc --plugin none && open docs/index.html",
-    "docs:md": "npm run docs:clean && typedoc --plugin typedoc-plugin-markdown --theme docusaurus2"
+    "docs:md": "npm run docs:clean && typedoc --plugin typedoc-plugin-markdown --hideBreadcrumbs --theme docusaurus2"
   },
   "dependencies": {
     "axios": "^0.19.0",


### PR DESCRIPTION
Adds a missed build artifact directory to `.gitignore`.

Part of https://github.com/comit-network/comit.network/pull/22