### PR TITLE
Change logo url to be absolute

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <a href="https://comit.network">
-  <img src="logo.svg" height="120px" />
+  <img src="https://github.com/comit-network/comit-js-sdk/blob/master/logo.svg" height="120px" />
 </a>
 
 ---


### PR DESCRIPTION
So the logo is properly displayed in the docs.

Noticed that the logo is not properly displayed in
https://deploy-preview-22--comit-network.netlify.com/docs/comit-sdk/index

which is preview of
https://github.com/comit-network/comit.network/pull/22