### PR TITLE
Add a check to ensure the dist/ folder is not ignored

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -11,6 +11,16 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: 10.x
+      - name: Check that dist folder is NOT gitignored
+        run: |
+          if [[ $(grep -c dist .gitignore) -eq 0 ]]
+            then
+              echo "dist/ is not gitignored"
+              exit 0
+            else
+              echo "dist/ is gitignored, we need to fail"
+              exit 1
+          fi
       - name: yarn install and test
         run: |
           yarn install

--- a/.gitignore
+++ b/.gitignore
@@ -2,8 +2,10 @@ node_modules/
 
 .idea/
 
+# NEVER GITIGNORE THE DIST folder
+# If you git ignore it then `npm/yarn publish` will NOT push it to npmjs.com.
+
 docs/
-dist/
 website/
 
 # This is a library

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Do not gitignore the `dist/` folder to ensure it is included in the published package, add a CI test to test it. 
+
 ## [0.11.0] - 2020-02-19
 
 ### Changed


### PR DESCRIPTION
Because otherwise the `dist/` folder is not included in the package.

Adding everyone in review so that nobody get surprised by the CI check.