### PR TITLE
Update prettier version

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@types/urijs": "^1.19.3",
     "jest": "^24.9.0",
     "nock": "^11.3.4",
-    "prettier": "^1.18.2",
+    "prettier": "^1.19.1",
     "ts-jest": "^24.1.0",
     "tslint": "^5.20.0",
     "tslint-config-prettier": "^1.18.0",


### PR DESCRIPTION
I had problems with the prettier version `"^1.18.2"` on my Mac, it would always touch the `siren.ts` file event though it should not. 
Updating version fixed this problem.

---

For reference, it would move the bracket on line `85` to line `84`:

```
      | "working-copy-of"
    );
/**
```

would become:

```
      | "working-copy-of");
/**
```

CI does not like that...