### PR TITLE
Fix pre commit hook

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -2,6 +2,4 @@
 
 set -e
 
-yarn run prettier
-yarn run lint
-yarn run check
+yarn run test

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "author": "CoBloX developers <team@coblox.tech>",
   "license": "Apache-2.0",
   "scripts": {
+    "pretest": "git config core.hooksPath .githooks",
     "prepare": "tsc",
     "fix": "tslint -p . --fix && prettier --write '**/*.{ts,js,json,yml}'",
     "test": "tsc --noEmit && tslint -p . && prettier --check '**/*.{ts,js,json,yml}' && jest",


### PR DESCRIPTION
1. The pre-commit hook script no longer worked because the scripts have been changed and merged into a single `test` script without updating the hook.
2. People seem to not use the hook otherwise we would have noticed earlier. The 2nd patch automatically installs the hooks again before running the tests.

At some point, each dev will run `yarn test` and therefore install the hooks again.

The pre-commit hook takes a bit longer now because all the checks have been merged into a single script `test`. I didn't change that because I assume it was on purpose.

If people don't want to run these checks on every commit, I recommend to split the script again.