### PR TITLE
Update logo to support dark mode

### DIFF
--- a/logo.svg
+++ b/logo.svg
@@ -1,45 +1,48 @@
 <svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
-     viewBox="0 0 4000 750">
+     viewBox="0 0 5000 750">
     <defs>
         <style>
             .small { font: 500px sans-serif; }
             .cls-1{fill:#2a3484;}.cls-2,.cls-3,.cls-4{opacity:0.64;}.cls-3{fill:url(#linear-gradient);}.cls-4{fill:url(#linear-gradient-3);}
         </style>
-        <linearGradient id="linear-gradient" x1="630.11" y1="225.6" x2="867.02" y2="474.66"
+        <linearGradient id="linear-gradient" x1="697.31" y1="225.6" x2="934.22" y2="474.66"
                         gradientUnits="userSpaceOnUse">
             <stop offset="0" stop-color="#0c1ce3"/>
             <stop offset="1" stop-color="#0ed1e1"/>
         </linearGradient>
-        <linearGradient id="linear-gradient-3" x1="630.11" y1="225.6" x2="867.02" y2="474.66"
-                        gradientTransform="translate(490.13 -435.74) rotate(45)" xlink:href="#linear-gradient"/>
+        <linearGradient id="linear-gradient-3" x1="697.31" y1="225.6" x2="934.22" y2="474.66"
+                        gradientTransform="translate(509.81 -483.25) rotate(45)" xlink:href="#linear-gradient"/>
+        <linearGradient id="linear-gradient-rect" x1="0%" y1="0%" x2="100%" y2="0%">
+            <stop offset="0%" style="stop-color:rgb(255,255,255);stop-opacity:1" />
+            <stop offset="100%" style="stop-color:rgb(255,255,255);stop-opacity:0" />
+        </linearGradient>
     </defs>
-    <title>COMITspellout_screen</title>
+    <title>COMITspellout_screenPLAIN</title>
+    <rect width="4000" height="100%" style="fill:rgb(255,255,255)" />
+    <rect x="4000" width="1000" height="100%" style="fill:url(#linear-gradient-rect)" />
     <path class="cls-1"
-          d="M598.3,629.82c-163.65-142.49-163.65-369.62,0-512.11l35.34,25c-71.29,71.25-107.25,148-107.25,231.4s36,160.15,107.25,231.4Z"/>
+          d="M665.5,629.82c-163.65-142.49-163.65-369.62,0-512.11l35.34,25c-71.29,71.25-107.25,148-107.25,231.4s36,160.15,107.25,231.4Z"/>
     <path class="cls-1"
-          d="M943.8,117.71c163.65,142.49,163.65,369.62,0,512.11l-35.34-24.35c71.29-71.25,107.25-148,107.25-231.4s-36-160.15-107.25-231.4Z"/>
+          d="M1011,117.71c163.65,142.49,163.65,369.62,0,512.11l-35.34-24.35c71.29-71.25,107.25-148,107.25-231.4s-36-160.15-107.25-231.4Z"/>
     <path class="cls-1"
-          d="M405.7,483.13c0,45.79-14.26,81.87-43.42,108.92S293,632.29,242.4,632.29c-51.19,0-92-20.81-123.12-62.44C87.53,528.23,72,472.72,72,402.65s16.2-124.19,48.6-163.74c32.4-38.85,73.87-58.28,125.06-58.28,87.48,0,140,51.35,160.06,126.27l-55.08,11.8c-17.5-54.81-55.73-88.81-105-88.81-34.34,0-62.21,15.27-84.88,45.79s-33.7,72.85-33.7,127c0,54.81,10.37,98.52,30.46,131.13S206.76,583,245.64,583c64.8,0,105-39.55,105-99.91Z"/>
+          d="M472.89,483.13c0,45.79-14.25,81.87-43.41,108.92s-69.34,40.24-119.88,40.24c-51.19,0-92-20.81-123.12-62.44-31.75-41.62-47.3-97.13-47.3-167.2s16.2-124.19,48.6-163.74c32.4-38.85,73.87-58.28,125.06-58.28,87.48,0,140,51.35,160.05,126.27l-55.08,11.8c-17.49-54.81-55.72-88.81-105-88.81-34.34,0-62.21,15.27-84.89,45.79s-33.69,72.85-33.69,127c0,54.81,10.36,98.52,30.45,131.13S274,583,312.84,583c64.8,0,105-39.55,105-99.91Z"/>
     <path class="cls-1"
-          d="M1128.1,624.66V188.27h73.23L1338.7,483.82l136.08-295.55h71.93V624.66h-51.19V266l-140,303.88h-34.34L1179.3,261.11V624.66Z"/>
-    <path class="cls-1" d="M1667.24,624.66V188.27h51.2V624.66Z"/>
-    <path class="cls-1" d="M1909.59,624.66V235.44H1776.76V188.27h316.86v47.17H1960.78V624.66Z"/>
-    <path class="cls-1" d="M2156.5,235.89V193.81h-14.36V188.7h34.25v5.11H2162v42.08Z"/>
-    <path class="cls-1"
-          d="M2182.76,235.89V188.7h7.92l14.85,32,14.71-32H2228v47.19h-5.53V197.11L2207.35,230h-3.71l-15.34-33.38v39.31Z"/>
+          d="M1195.3,624.66V188.27h73.23L1405.9,483.82,1542,188.27h71.92V624.66h-51.19V266l-140,303.88H1388.4L1246.49,261.11V624.66Z"/>
+    <path class="cls-1" d="M1734.44,624.66V188.27h51.19V624.66Z"/>
+    <path class="cls-1" d="M1976.79,624.66V235.44H1844V188.27h316.87v47.17H2028V624.66Z"/>
     <g class="cls-2">
-        <ellipse class="cls-3" cx="771.05" cy="373.76" rx="180.09" ry="77.55"/>
+        <ellipse class="cls-3" cx="838.24" cy="373.76" rx="180.09" ry="77.55"/>
     </g>
     <g class="cls-2">
-        <ellipse class="cls-3" cx="771.05" cy="373.76" rx="77.55" ry="180.09"/>
+        <ellipse class="cls-3" cx="838.24" cy="373.76" rx="77.55" ry="180.09"/>
     </g>
     <g class="cls-2">
-        <ellipse class="cls-4" cx="771.05" cy="373.76" rx="77.55" ry="180.09"
-                 transform="translate(-38.46 654.68) rotate(-45)"/>
+        <ellipse class="cls-4" cx="838.24" cy="373.76" rx="77.55" ry="180.09"
+                 transform="translate(-18.78 702.2) rotate(-45)"/>
     </g>
     <g class="cls-2">
-        <ellipse class="cls-4" cx="771.05" cy="373.76" rx="180.09" ry="77.55"
-                 transform="translate(-38.46 654.68) rotate(-45)"/>
+        <ellipse class="cls-4" cx="838.24" cy="373.76" rx="180.09" ry="77.55"
+                 transform="translate(-18.78 702.2) rotate(-45)"/>
     </g>
     <text x="2300" y="630" class="small">js-SDK</text>
 </svg>


### PR DESCRIPTION
* Update logo to version without TM (as updated in notion)
* Add a white rectangle and gradient rectangle for good looks

Resolves: https://github.com/comit-network/comit.network/issues/31
