### PR TITLE
Explicit names for Taker- and MakerNegotiator

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -34,8 +34,8 @@ export {
   isValidExecutionParams,
   NetworkType
 } from "./negotiation/execution_params";
-export { MakerNegotiator } from "./negotiation/maker/negotiator";
-export { TakerNegotiator } from "./negotiation/taker/negotiator";
+export { MakerNegotiator } from "./negotiation/maker/maker_negotiator";
+export { TakerNegotiator } from "./negotiation/taker/taker_negotiator";
 
 export { TryParams } from "./util/timeout_promise";
 export { Lnd } from "./lnd";

--- a/src/negotiation/maker/maker_negotiator.ts
+++ b/src/negotiation/maker/maker_negotiator.ts
@@ -6,13 +6,11 @@ import { ExecutionParams } from "../execution_params";
 import { isOrderValid, Order, toTradingPair } from "../order";
 import orderSwapMatches from "./swap_order_matching";
 
-export { Negotiator as MakerNegotiator };
-
 /**
  * Handles the negotiation on the maker side of a trade.
  * Bundles functionality to create orders for a maker and make them available for the taker.
  */
-class Negotiator {
+export class MakerNegotiator {
   private ordersByTradingPair: { [tradingPair: string]: Order } = {};
   private ordersById: { [orderId: string]: Order } = {};
   private readonly executionParams: ExecutionParams;

--- a/src/negotiation/taker/taker_negotiator.spec.ts
+++ b/src/negotiation/taker/taker_negotiator.spec.ts
@@ -8,8 +8,8 @@ import {
   // @ts-ignore: tslint does not know that this is actually ./__mocks__/maker_client
   mockGetOrderByTradingPair
 } from "./maker_client";
-import { TakerNegotiator } from "./negotiator";
 import { MatchingCriteria } from "./order";
+import { TakerNegotiator } from "./taker_negotiator";
 
 jest.mock("./maker_client");
 jest.mock("../../wallet/ethereum");

--- a/src/negotiation/taker/taker_negotiator.ts
+++ b/src/negotiation/taker/taker_negotiator.ts
@@ -15,13 +15,11 @@ import {
   TakerOrder
 } from "./order";
 
-export { Negotiator as TakerNegotiator };
-
 /**
  * Handles the negotiation on the taker side of a trade.
  * Bundles functionality to get orders from a maker, take them and initiate the swap execution.
  */
-class Negotiator {
+export class TakerNegotiator {
   private static newSwapRequest(
     rawOrder: Order,
     executionParams: ExecutionParams
@@ -90,7 +88,7 @@ class Negotiator {
       return;
     }
 
-    const swapRequest = Negotiator.newSwapRequest(order, executionParams);
+    const swapRequest = TakerNegotiator.newSwapRequest(order, executionParams);
     if (!swapRequest) {
       return;
     }


### PR DESCRIPTION
Files with same name cause problem when rendering the documentation. There are 2 `Negotiator` entries displayed under `Classes` and it is just not visible which is which.
Making the names explicit does not add disadvantages.