### PR TITLE
Extend Cnd class with middleware for parsing problem responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Cnd's error responses follow the RFC7807 format.
+The SDK now recognizes this: Promises returned from calls on `Cnd` will now reject with an instance of `Problem` that contains more detailed information, why the request failed.
+
 ## [0.14.0] - 2020-03-05
 
 ### Changed

--- a/src/cnd/axios_rfc7807_middleware.ts
+++ b/src/cnd/axios_rfc7807_middleware.ts
@@ -1,0 +1,53 @@
+import { AxiosError } from "axios";
+import contentType from "content-type";
+
+export class Problem extends Error {
+  public readonly type: string;
+  public readonly title: string;
+  public readonly status?: number;
+  public readonly detail?: string;
+  public readonly instance?: string;
+
+  constructor({ title, type, status, detail, instance }: ProblemMembers) {
+    super(title);
+    this.type = type || "about:blank";
+    this.status = status;
+    this.detail = detail;
+    this.instance = instance;
+    this.title = title;
+  }
+}
+
+interface ProblemMembers {
+  title: string;
+  type?: string;
+  status?: number;
+  detail?: string;
+  instance?: string;
+}
+
+export async function problemResponseInterceptor(
+  error: AxiosError
+): Promise<AxiosError | Problem> {
+  const response = error.response;
+
+  if (!response) {
+    return Promise.reject(error);
+  }
+
+  const rawContentType = response.headers["content-type"];
+
+  if (!rawContentType) {
+    return Promise.reject(error);
+  }
+
+  const parsedContentType = contentType.parse(rawContentType).type;
+
+  if (parsedContentType !== "application/problem+json") {
+    return Promise.reject(error);
+  }
+
+  const responseBody = response.data;
+
+  return Promise.reject(new Problem(responseBody));
+}

--- a/src/cnd/cnd.spec.ts
+++ b/src/cnd/cnd.spec.ts
@@ -1,0 +1,102 @@
+import nock = require("nock");
+import { Problem } from "./axios_rfc7807_middleware";
+import { Cnd } from "./cnd";
+
+it.each([
+  ["500", "Internal Server Error", "about:blank", null],
+  ["405", "Invalid action invocation", null, null],
+  [
+    "400",
+    "Swap not supported",
+    "about:blank",
+    "The requested combination of ledgers and assets is not supported."
+  ]
+])(
+  "should return a Problem if the response is application/problem+json",
+  (status, title, type, detail) =>
+    setup(async (interceptor, postSwap) => {
+      const statusCode = parseInt(status!, 10);
+
+      const scope = interceptor.reply(
+        statusCode,
+        JSON.stringify({ status, title, type, detail }),
+        {
+          "content-type": "application/problem+json"
+        }
+      );
+
+      const promise = postSwap();
+
+      await expect(promise).rejects.toStrictEqual(
+        new Problem({
+          title: title!,
+          detail: detail!,
+          status: statusCode,
+          type: type!
+        })
+      );
+
+      return scope;
+    })
+);
+
+it("should return a generic axios error if the status code is fauly and the content type is not application/problem+json", () =>
+  setup(async (interceptor, postSwap) => {
+    const scope = interceptor.reply(400, JSON.stringify({}), {
+      "content-type": "application/json"
+    });
+
+    const promise = postSwap();
+
+    await expect(promise).rejects.toEqual(
+      new Error("Request failed with status code 400")
+    );
+
+    return scope;
+  }));
+
+it("cnd should not throw an error if the response is application/vnd.siren+json", () =>
+  setup(async (interceptor, postSwap) => {
+    const scope = interceptor.reply(201, JSON.stringify({}), {
+      "content-type": "application/vnd.siren+json",
+      location: "http://example.com/foo/bar"
+    });
+
+    const location = await postSwap();
+
+    expect(location).toBe("http://example.com/foo/bar");
+
+    return scope;
+  }));
+
+/**
+ * Sets up a test environment around the `postSwap` call.
+ *
+ * For this we setup nock and a Cnd instance that is pointing to the same endpoint.
+ * The actual test function is passed this interceptor to customize, what the return value should be.
+ * We also pass a function or triggering the `postSwap` call to it.
+ *
+ * This allows the testFn to focus on the bare minimum required to understand the test:
+ *
+ * 1. what to we return from the route
+ * 2. how do we expect the `Cnd` instance to behave
+ *
+ * @param testFn The actual, customized test function.
+ * @returns a test function, ready to be passed to the test framework
+ */
+async function setup(
+  testFn: (
+    interceptor: nock.Interceptor,
+    postSwap: () => Promise<string>
+  ) => Promise<nock.Scope>
+): Promise<void> {
+  const basePath = "http://example.com";
+  const cnd = new Cnd(basePath);
+
+  const intercepter = nock(basePath).post("/swaps/rfc003");
+  const postSwap = () => cnd.postSwap({} as any);
+
+  const scope = await testFn(intercepter, postSwap);
+
+  scope.done();
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ export {
   SwapRequest,
   SwapDetails
 } from "./cnd/cnd";
+export { Problem } from "./cnd/axios_rfc7807_middleware";
 export * from "./cnd/siren";
 
 export { Actor, createActor } from "./actor";


### PR DESCRIPTION
We use axios interceptor functionality to parse responses of type 'application/problem+json' into a Problem class. This allows us to know about the fields present in the response and return a dedicated error to the user with useful information of what went wrong.

Resolves #122.