### PR TITLE
Document cnd errors, wrap cnd & wallet errors in specialised Error classes

### DIFF
--- a/src/cnd/axios_rfc7807_middleware.ts
+++ b/src/cnd/axios_rfc7807_middleware.ts
@@ -7,6 +7,7 @@ export class Problem extends Error {
   public readonly status?: number;
   public readonly detail?: string;
   public readonly instance?: string;
+  public readonly isProblem: boolean;
 
   constructor({ title, type, status, detail, instance }: ProblemMembers) {
     super(title);
@@ -15,6 +16,7 @@ export class Problem extends Error {
     this.detail = detail;
     this.instance = instance;
     this.title = title;
+    this.isProblem = true;
   }
 }
 

--- a/src/cnd/axios_rfc7807_middleware.ts
+++ b/src/cnd/axios_rfc7807_middleware.ts
@@ -7,7 +7,6 @@ export class Problem extends Error {
   public readonly status?: number;
   public readonly detail?: string;
   public readonly instance?: string;
-  public readonly isProblem: boolean;
 
   constructor({ title, type, status, detail, instance }: ProblemMembers) {
     super(title);
@@ -16,7 +15,6 @@ export class Problem extends Error {
     this.detail = detail;
     this.instance = instance;
     this.title = title;
-    this.isProblem = true;
   }
 }
 

--- a/src/cnd/cnd.spec.ts
+++ b/src/cnd/cnd.spec.ts
@@ -93,10 +93,10 @@ async function setup(
   const basePath = "http://example.com";
   const cnd = new Cnd(basePath);
 
-  const intercepter = nock(basePath).post("/swaps/rfc003");
+  const interceptor = nock(basePath).post("/swaps/rfc003");
   const postSwap = () => cnd.postSwap({} as any);
 
-  const scope = await testFn(intercepter, postSwap);
+  const scope = await testFn(interceptor, postSwap);
 
   scope.done();
 }

--- a/src/cnd/cnd.ts
+++ b/src/cnd/cnd.ts
@@ -259,15 +259,27 @@ export class Cnd {
     );
   }
 
+  /**
+   * Get the peer id of the cnd node
+   *
+   * @returns Promise that resolves with the peer id of the cnd node,
+   * @throws A {@link Problem} from the cnd REST API or an {@link Error}.
+   */
   public async getPeerId(): Promise<string> {
     const info = await this.getInfo();
     if (!info.id) {
-      throw new Error("id field not present");
+      return Promise.reject(new Error("id field not present"));
     }
 
     return info.id;
   }
 
+  /**
+   * Get the address on which cnd is listening for peer-to-peer/COMIT messages.
+   *
+   * @returns An array of multiaddresses
+   * @throws A {@link Problem} from the cnd REST API or an {@link Error}.
+   */
   public async getPeerListenAddresses(): Promise<string[]> {
     const info = await this.getInfo();
     if (!info.listen_addresses) {
@@ -277,12 +289,25 @@ export class Cnd {
     return info.listen_addresses;
   }
 
+  /**
+   * Sends a swap request to cnd.
+   *
+   * @param swap The details of the swap to initiate.
+   * @returns The URL of the swap request on the cnd REST API.
+   * @throws A {@link Problem} from the cnd REST API or an {@link Error}.
+   */
   public async postSwap(swap: SwapRequest): Promise<string> {
     const response = await this.client.post("swaps/rfc003", swap);
 
     return response.headers.location;
   }
 
+  /**
+   * List the swaps handled by this cnd instance.
+   *
+   * @returns An Array of {@link SwapSubEntity}, which contains details of the swaps.
+   * @throws A {@link Problem} from the cnd REST API or an {@link Error}.
+   */
   public async getSwaps(): Promise<SwapSubEntity[]> {
     const response = await this.fetch("swaps");
     const entity = response.data as Entity;
@@ -290,10 +315,27 @@ export class Cnd {
     return entity.entities as SwapSubEntity[];
   }
 
+  /**
+   * Fetch data from the REST API.
+   *
+   * @param path The URL to GET.
+   * @returns The data returned by cnd.
+   * @throws A {@link Problem} from the cnd REST API or an {@link Error}.
+   */
   public fetch<T>(path: string): AxiosPromise<T> {
     return this.client.get(path);
   }
 
+  /**
+   * Proceed with an action request on the cnd REST API.
+   * This request could be a GET HTTP request, which only returns data needed to further proceed with the action,
+   * or a POST request, which is the action itself, to instruct cnd about a swap.
+   *
+   * @param action The action to perform.
+   * @param resolver A function that returns data needed to perform the action, this data is likely to be provided by a
+   * blockchain wallet or interface (e.g. wallet address).
+   * @throws A {@link Problem} from the cnd REST API, or {@link ChainError} if the blockchain wallet throws, or an {@link Error}.
+   */
   public async executeSirenAction(
     action: Action,
     resolver?: FieldValueResolverFn

--- a/src/cnd/cnd.ts
+++ b/src/cnd/cnd.ts
@@ -334,7 +334,7 @@ export class Cnd {
    * @param action The action to perform.
    * @param resolver A function that returns data needed to perform the action, this data is likely to be provided by a
    * blockchain wallet or interface (e.g. wallet address).
-   * @throws A {@link Problem} from the cnd REST API, or {@link ChainError} if the blockchain wallet throws, or an {@link Error}.
+   * @throws A {@link Problem} from the cnd REST API, or {@link WalletError} if the blockchain wallet throws, or an {@link Error}.
    */
   public async executeSirenAction(
     action: Action,

--- a/src/cnd/cnd.ts
+++ b/src/cnd/cnd.ts
@@ -328,8 +328,6 @@ export class Cnd {
 
   /**
    * Proceed with an action request on the cnd REST API.
-   * This request could be a GET HTTP request, which only returns data needed to further proceed with the action,
-   * or a POST request, which is the action itself, to instruct cnd about a swap.
    *
    * @param action The action to perform.
    * @param resolver A function that returns data needed to perform the action, this data is likely to be provided by a

--- a/src/cnd/cnd.ts
+++ b/src/cnd/cnd.ts
@@ -268,7 +268,7 @@ export class Cnd {
   public async getPeerId(): Promise<string> {
     const info = await this.getInfo();
     if (!info.id) {
-      return Promise.reject(new Error("id field not present"));
+      throw new Error("id field not present");
     }
 
     return info.id;

--- a/src/swap.spec.ts
+++ b/src/swap.spec.ts
@@ -1,6 +1,6 @@
 import nock = require("nock");
 import { Problem } from "./cnd/axios_rfc7807_middleware";
-import { Cnd, SwapDetails } from "./cnd/cnd";
+import { Cnd, LedgerAction, SwapDetails } from "./cnd/cnd";
 import { ChainError, Swap } from "./swap";
 
 describe("Swap", () => {
@@ -38,7 +38,7 @@ describe("Swap", () => {
     return scope;
   });
 
-  it("Throws a ChainError if a wallet returns an error when executing an action", async () => {
+  it("Throws a ChainError if a wallet returns an error when resolving fields", async () => {
     const basePath = "http://example.com";
     const cnd = new Cnd(basePath);
 
@@ -69,5 +69,62 @@ describe("Swap", () => {
     await expect(promise).rejects.toBeInstanceOf(ChainError);
 
     return scope;
+  });
+
+  it("Throws a ChainError if a wallet returns an error when executing an action", async () => {
+    const basePath = "http://example.com";
+    const cnd = new Cnd(basePath);
+
+    const selfPath = "/swap-id";
+
+    const swap = new Swap(cnd, `${basePath}/swap-id`, {});
+
+    const swapDetails: SwapDetails = {
+      actions: [
+        {
+          href: "/swap-id/deploy",
+          name: "deploy",
+          method: "GET"
+        }
+      ]
+    };
+
+    const swapScope = nock(basePath)
+      .get(selfPath)
+      .times(2)
+      .reply(200, JSON.stringify(swapDetails), {});
+
+    const actionPayload = {
+      type: "ethereum-deploy-contract",
+      payload: {
+        data: "",
+        amount: "",
+        gas_limit: "",
+        network: ""
+      }
+    };
+
+    const actionScope = nock(basePath)
+      .get("/swap-id/deploy")
+      .times(2)
+      .reply(200, JSON.stringify(actionPayload), {});
+
+    const tryParams = {
+      maxTimeoutSecs: 1,
+      tryIntervalSecs: 0.01
+    };
+
+    // To be sure we are testing the right thing, we verify this does not throws
+    const executeActionPromise = swap.tryExecuteSirenAction<LedgerAction>(
+      "deploy",
+      tryParams
+    );
+    await expect(executeActionPromise).resolves;
+
+    const promise = swap.deploy(tryParams);
+
+    await expect(promise).rejects.toBeInstanceOf(ChainError);
+
+    return { swapScope, actionScope };
   });
 });

--- a/src/swap.spec.ts
+++ b/src/swap.spec.ts
@@ -1,7 +1,7 @@
 import nock = require("nock");
 import { Problem } from "./cnd/axios_rfc7807_middleware";
-import { Cnd } from "./cnd/cnd";
-import { Swap } from "./swap";
+import { Cnd, SwapDetails } from "./cnd/cnd";
+import { ChainError, Swap } from "./swap";
 
 describe("Swap", () => {
   it("Throws a problem if cnd returns an error when executing an action", async () => {
@@ -34,6 +34,39 @@ describe("Swap", () => {
     });
 
     await expect(promise).rejects.toBeInstanceOf(Problem);
+
+    return scope;
+  });
+
+  it("Throws a ChainError if a wallet returns an error when executing an action", async () => {
+    const basePath = "http://example.com";
+    const cnd = new Cnd(basePath);
+
+    const selfPath = "/swap-id";
+
+    const swap = new Swap(cnd, `${basePath}/swap-id`, {});
+
+    const swapDetails: SwapDetails = {
+      actions: [
+        {
+          href: "/swap-id/action",
+          name: "action",
+          method: "GET",
+          fields: [{ name: "address", class: ["bitcoin", "address"] }]
+        }
+      ]
+    };
+
+    const scope = nock(basePath)
+      .get(selfPath)
+      .reply(200, JSON.stringify(swapDetails), {});
+
+    const promise = swap.tryExecuteSirenAction("action", {
+      maxTimeoutSecs: 1,
+      tryIntervalSecs: 0.01
+    });
+
+    await expect(promise).rejects.toBeInstanceOf(ChainError);
 
     return scope;
   });

--- a/src/swap.spec.ts
+++ b/src/swap.spec.ts
@@ -110,7 +110,7 @@ describe("Swap", () => {
       tryIntervalSecs: 0.01
     };
 
-    // To be sure we are testing the right thing, we verify this does not throws
+    // To be sure we are testing the right thing, we verify this does not throw
     const executeActionPromise = swap.tryExecuteSirenAction<LedgerAction>(
       "deploy",
       tryParams

--- a/src/swap.spec.ts
+++ b/src/swap.spec.ts
@@ -1,0 +1,40 @@
+import nock = require("nock");
+import { Problem } from "./cnd/axios_rfc7807_middleware";
+import { Cnd } from "./cnd/cnd";
+import { Swap } from "./swap";
+
+describe("Swap", () => {
+  it("Throws a problem if cnd returns an error when executing an action", async () => {
+    const basePath = "http://example.com";
+    const cnd = new Cnd(basePath);
+
+    const selfPath = "/swap-id";
+
+    const swap = new Swap(cnd, selfPath, {});
+
+    const scope = nock(basePath)
+      .get(selfPath)
+      .reply(
+        400,
+        JSON.stringify({
+          status: "400",
+          title: "Swap not supported",
+          type: "about:blank",
+          detail:
+            "The requested combination of ledgers and assets is not supported."
+        }),
+        {
+          "content-type": "application/problem+json"
+        }
+      );
+
+    const promise = swap.tryExecuteSirenAction("action", {
+      maxTimeoutSecs: 1,
+      tryIntervalSecs: 0.01
+    });
+
+    await expect(promise).rejects.toBeInstanceOf(Problem);
+
+    return scope;
+  });
+});

--- a/src/swap.spec.ts
+++ b/src/swap.spec.ts
@@ -1,7 +1,7 @@
 import nock = require("nock");
 import { Problem } from "./cnd/axios_rfc7807_middleware";
 import { Cnd, LedgerAction, SwapDetails } from "./cnd/cnd";
-import { ChainError, Swap } from "./swap";
+import { Swap, WalletError } from "./swap";
 
 describe("Swap", () => {
   it("Throws a problem if cnd returns an error when executing an action", async () => {
@@ -36,7 +36,7 @@ describe("Swap", () => {
     await expect(promise).rejects.toBeInstanceOf(Problem);
   });
 
-  it("Throws a ChainError if a wallet returns an error when resolving fields", async () => {
+  it("Throws a WalletError if a wallet returns an error when resolving fields", async () => {
     const basePath = "http://example.com";
     const cnd = new Cnd(basePath);
 
@@ -64,10 +64,10 @@ describe("Swap", () => {
       tryIntervalSecs: 0.01
     });
 
-    await expect(promise).rejects.toBeInstanceOf(ChainError);
+    await expect(promise).rejects.toBeInstanceOf(WalletError);
   });
 
-  it("Throws a ChainError if a wallet returns an error when executing an action", async () => {
+  it("Throws a WalletError if a wallet returns an error when executing an action", async () => {
     const basePath = "http://example.com";
     const cnd = new Cnd(basePath);
 
@@ -119,6 +119,6 @@ describe("Swap", () => {
 
     const promise = swap.deploy(tryParams);
 
-    await expect(promise).rejects.toBeInstanceOf(ChainError);
+    await expect(promise).rejects.toBeInstanceOf(WalletError);
   });
 });

--- a/src/swap.spec.ts
+++ b/src/swap.spec.ts
@@ -1,6 +1,5 @@
-import nock = require("nock");
 import { Problem } from "./cnd/axios_rfc7807_middleware";
-import { Cnd, LedgerAction, SwapDetails } from "./cnd/cnd";
+import { Cnd } from "./cnd/cnd";
 import { Swap, WalletError } from "./swap";
 
 describe("Swap", () => {
@@ -12,21 +11,9 @@ describe("Swap", () => {
 
     const swap = new Swap(cnd, selfPath, {});
 
-    nock(basePath)
-      .get(selfPath)
-      .reply(
-        400,
-        JSON.stringify({
-          status: "400",
-          title: "Swap not supported",
-          type: "about:blank",
-          detail:
-            "The requested combination of ledgers and assets is not supported."
-        }),
-        {
-          "content-type": "application/problem+json"
-        }
-      );
+    cnd.fetch = jest.fn(async () => {
+      throw new Problem({ title: "" });
+    });
 
     const promise = swap.tryExecuteSirenAction("action", {
       maxTimeoutSecs: 1,
@@ -40,24 +27,23 @@ describe("Swap", () => {
     const basePath = "http://example.com";
     const cnd = new Cnd(basePath);
 
-    const selfPath = "/swap-id";
-
     const swap = new Swap(cnd, `${basePath}/swap-id`, {});
 
-    const swapDetails: SwapDetails = {
-      actions: [
-        {
-          href: "/swap-id/action",
-          name: "action",
-          method: "GET",
-          fields: [{ name: "address", class: ["bitcoin", "address"] }]
+    // @ts-ignore: This should return an AxiosPromise
+    cnd.fetch = jest.fn(async () => {
+      return {
+        data: {
+          actions: [
+            {
+              href: "/swap-id/action",
+              name: "action",
+              method: "GET",
+              fields: [{ name: "address", class: ["bitcoin", "address"] }]
+            }
+          ]
         }
-      ]
-    };
-
-    nock(basePath)
-      .get(selfPath)
-      .reply(200, JSON.stringify(swapDetails), {});
+      };
+    });
 
     const promise = swap.tryExecuteSirenAction("action", {
       maxTimeoutSecs: 1,
@@ -71,51 +57,42 @@ describe("Swap", () => {
     const basePath = "http://example.com";
     const cnd = new Cnd(basePath);
 
-    const selfPath = "/swap-id";
-
     const swap = new Swap(cnd, `${basePath}/swap-id`, {});
 
-    const swapDetails: SwapDetails = {
-      actions: [
-        {
-          href: "/swap-id/deploy",
-          name: "deploy",
-          method: "GET"
+    // @ts-ignore: This should return an AxiosPromise
+    cnd.fetch = jest.fn(async () => {
+      return {
+        data: {
+          actions: [
+            {
+              href: "/swap-id/deploy",
+              name: "deploy",
+              method: "GET"
+            }
+          ]
         }
-      ]
-    };
+      };
+    });
 
-    nock(basePath)
-      .get(selfPath)
-      .times(2)
-      .reply(200, JSON.stringify(swapDetails), {});
-
-    const actionPayload = {
-      type: "ethereum-deploy-contract",
-      payload: {
-        data: "",
-        amount: "",
-        gas_limit: "",
-        network: ""
-      }
-    };
-
-    nock(basePath)
-      .get("/swap-id/deploy")
-      .times(2)
-      .reply(200, JSON.stringify(actionPayload), {});
+    // @ts-ignore: This should return an AxiosPromise
+    cnd.executeSirenAction = jest.fn(async () => {
+      return {
+        data: {
+          type: "ethereum-deploy-contract",
+          payload: {
+            data: "",
+            amount: "",
+            gas_limit: "",
+            network: ""
+          }
+        }
+      };
+    });
 
     const tryParams = {
       maxTimeoutSecs: 1,
       tryIntervalSecs: 0.01
     };
-
-    // To be sure we are testing the right thing, we verify this does not throw
-    const executeActionPromise = swap.tryExecuteSirenAction<LedgerAction>(
-      "deploy",
-      tryParams
-    );
-    await expect(executeActionPromise).resolves;
 
     const promise = swap.deploy(tryParams);
 

--- a/src/swap.spec.ts
+++ b/src/swap.spec.ts
@@ -12,7 +12,7 @@ describe("Swap", () => {
 
     const swap = new Swap(cnd, selfPath, {});
 
-    const scope = nock(basePath)
+    nock(basePath)
       .get(selfPath)
       .reply(
         400,
@@ -34,8 +34,6 @@ describe("Swap", () => {
     });
 
     await expect(promise).rejects.toBeInstanceOf(Problem);
-
-    return scope;
   });
 
   it("Throws a ChainError if a wallet returns an error when resolving fields", async () => {
@@ -57,7 +55,7 @@ describe("Swap", () => {
       ]
     };
 
-    const scope = nock(basePath)
+    nock(basePath)
       .get(selfPath)
       .reply(200, JSON.stringify(swapDetails), {});
 
@@ -67,8 +65,6 @@ describe("Swap", () => {
     });
 
     await expect(promise).rejects.toBeInstanceOf(ChainError);
-
-    return scope;
   });
 
   it("Throws a ChainError if a wallet returns an error when executing an action", async () => {
@@ -89,7 +85,7 @@ describe("Swap", () => {
       ]
     };
 
-    const swapScope = nock(basePath)
+    nock(basePath)
       .get(selfPath)
       .times(2)
       .reply(200, JSON.stringify(swapDetails), {});
@@ -104,7 +100,7 @@ describe("Swap", () => {
       }
     };
 
-    const actionScope = nock(basePath)
+    nock(basePath)
       .get("/swap-id/deploy")
       .times(2)
       .reply(200, JSON.stringify(actionPayload), {});
@@ -124,7 +120,5 @@ describe("Swap", () => {
     const promise = swap.deploy(tryParams);
 
     await expect(promise).rejects.toBeInstanceOf(ChainError);
-
-    return { swapScope, actionScope };
   });
 });

--- a/src/swap.ts
+++ b/src/swap.ts
@@ -122,7 +122,7 @@ export class Swap {
   /**
    * Fetch the details of a swap.
    *
-   * @return The details of the swap at returned by cnd REST API.
+   * @return The details of the swap are returned by cnd REST API.
    * @throws A {@link Problem} from the cnd REST API or an {@link Error}.
    */
   public async fetchDetails(): Promise<SwapDetails> {

--- a/src/swap.ts
+++ b/src/swap.ts
@@ -11,7 +11,7 @@ export class WalletError extends Error {
     public readonly source: Error,
     public readonly callParams: any
   ) {
-    super(source.message);
+    super(JSON.stringify(source));
   }
 }
 

--- a/src/swap.ts
+++ b/src/swap.ts
@@ -11,7 +11,7 @@ export class WalletError extends Error {
     public readonly source: Error,
     public readonly callParams: any
   ) {
-    super(JSON.stringify(source));
+    super(source.message);
   }
 }
 

--- a/src/swap.ts
+++ b/src/swap.ts
@@ -6,16 +6,12 @@ import { sleep, timeoutPromise, TryParams } from "./util/timeout_promise";
 import { AllWallets, Wallets } from "./wallet";
 
 export class ChainError extends Error {
-  public readonly isChainError: boolean;
-
   constructor(
     public readonly attemptedAction: string,
     public readonly callError: Error,
     public readonly callParams: any
   ) {
     super(callError.message);
-
-    this.isChainError = true;
   }
 }
 

--- a/src/swap.ts
+++ b/src/swap.ts
@@ -5,6 +5,20 @@ import { Field } from "./cnd/siren";
 import { sleep, timeoutPromise, TryParams } from "./util/timeout_promise";
 import { AllWallets, Wallets } from "./wallet";
 
+export class ChainError extends Error {
+  public readonly isChainError: boolean;
+
+  constructor(
+    public readonly attemptedAction: string,
+    public readonly callError: Error,
+    public readonly callParams: any
+  ) {
+    super(callError.message);
+
+    this.isChainError = true;
+  }
+}
+
 /**
  * A stateful class that represents a single swap.
  *
@@ -26,6 +40,7 @@ export class Swap {
    * If the {@link Swap} is not in the right state this call will throw a timeout exception.
    *
    * @param tryParams Controls at which stage the exception is thrown.
+   * @throws A {@link Problem} from the cnd REST API or an {@link Error}.
    */
   public async accept(tryParams: TryParams): Promise<void> {
     await this.tryExecuteSirenAction<void>("accept", tryParams);
@@ -36,6 +51,7 @@ export class Swap {
    * If the {@link Swap} is not in the right state this call will throw a timeout exception.
    *
    * @param tryParams Controls at which stage the exception is thrown.
+   * @throws A {@link Problem} from the cnd REST API or an {@link Error}.
    */
   public async decline(tryParams: TryParams): Promise<void> {
     await this.tryExecuteSirenAction<void>("decline", tryParams);
@@ -49,6 +65,7 @@ export class Swap {
    *
    * @param tryParams Controls at which stage the exception is thrown.
    * @returns The hash of the transaction that was sent to the blockchain network.
+   * @throws A {@link Problem} from the cnd REST API, or {@link ChainError} if the blockchain wallet throws, or an {@link Error}.
    */
   public async deploy(tryParams: TryParams): Promise<string> {
     const response = await this.tryExecuteSirenAction<LedgerAction>(
@@ -64,6 +81,7 @@ export class Swap {
    *
    * @param tryParams Controls at which stage the exception is thrown.
    * @returns The hash of the transaction that was sent to the blockchain network.
+   * @throws A {@link Problem} from the cnd REST API, or {@link ChainError} if the blockchain wallet throws, or an {@link Error}.
    */
   public async fund(tryParams: TryParams): Promise<string> {
     const response = await this.tryExecuteSirenAction<LedgerAction>(
@@ -79,6 +97,7 @@ export class Swap {
    *
    * @param tryParams Controls at which stage the exception is thrown.
    * @returns The hash of the transaction that was sent to the blockchain network.
+   * @throws A {@link Problem} from the cnd REST API, or {@link ChainError} if the blockchain wallet throws, or an {@link Error}.
    */
   public async redeem(tryParams: TryParams): Promise<string> {
     const response = await this.tryExecuteSirenAction<LedgerAction>(
@@ -93,7 +112,8 @@ export class Swap {
    * If the {@link Swap} is not in the right state this call will throw a timeout exception.
    *
    * @param tryParams Controls at which stage the exception is thrown.
-   * @returns The hash of the transaction that was sent to the blockchain network.
+   * @returns The result of the refund action, a hash of the transaction that was sent to the blockchain.
+   * @throws A {@link Problem} from the cnd REST API, or {@link ChainError} if the blockchain wallet throws, or an {@link Error}.
    */
   public async refund(tryParams: TryParams): Promise<string> {
     const response = await this.tryExecuteSirenAction<LedgerAction>(
@@ -103,6 +123,12 @@ export class Swap {
     return this.doLedgerAction(response.data);
   }
 
+  /**
+   * Fetch the details of a swap.
+   *
+   * @return The details of the swap at returned by cnd REST API.
+   * @throws A {@link Problem} from the cnd REST API or an {@link Error}.
+   */
   public async fetchDetails(): Promise<SwapDetails> {
     const response = await this.cnd.fetch<SwapDetails>(this.self);
     return response.data;
@@ -112,10 +138,14 @@ export class Swap {
    * Low level API for executing actions on the {@link Swap}.
    *
    * If you are using any of the above actions ({@link Swap.redeem}, etc) you shouldn't need to use this.
+   * This only performs an action on the CND REST API, if an action is needed on another system (e.g blockchain wallet),
+   * then the needed information is returned by this function and needs to be processed with {@link doLedgerAction}.
    *
    * @param actionName The name of the Siren action you want to execute.
    * @param tryParams Controls at which stage the exception is thrown.
-   * @returns The response from {@link Cnd}. The actual response depends on the action you executed (hence the type parameter).
+   * @returns The response from {@link Cnd}. The actual response depends on the action you executed (hence the
+   * type parameter).
+   * @throws A {@link Problem} from the cnd REST API, or {@link ChainError} if the blockchain wallet throws, or an {@link Error}.
    */
   public async tryExecuteSirenAction<R>(
     actionName: string,
@@ -133,34 +163,59 @@ export class Swap {
    * Uses the wallets given in the constructor to send transactions according to the given ledger action.
    *
    * @param ledgerAction The ledger action returned from {@link Cnd}.
+   * @throws A {@link ChainError} if a wallet or blockchain action failed.
    */
   public async doLedgerAction(ledgerAction: LedgerAction): Promise<string> {
     switch (ledgerAction.type) {
       case "bitcoin-broadcast-signed-transaction": {
         const { hex, network } = ledgerAction.payload;
 
-        return this.wallets.bitcoin.broadcastTransaction(hex, network);
+        try {
+          return this.wallets.bitcoin.broadcastTransaction(hex, network);
+        } catch (error) {
+          throw new ChainError(ledgerAction.type, error, { hex, network });
+        }
       }
       case "bitcoin-send-amount-to-address": {
         const { to, amount, network } = ledgerAction.payload;
         const sats = parseInt(amount, 10);
 
-        return this.wallets.bitcoin.sendToAddress(to, sats, network);
+        try {
+          return this.wallets.bitcoin.sendToAddress(to, sats, network);
+        } catch (error) {
+          throw new ChainError(ledgerAction.type, error, { to, sats, network });
+        }
       }
       case "ethereum-call-contract": {
         const { data, contract_address, gas_limit } = ledgerAction.payload;
 
-        return this.wallets.ethereum.callContract(
-          data,
-          contract_address,
-          gas_limit
-        );
+        try {
+          return this.wallets.ethereum.callContract(
+            data,
+            contract_address,
+            gas_limit
+          );
+        } catch (error) {
+          throw new ChainError(ledgerAction.type, error, {
+            data,
+            contract_address,
+            gas_limit
+          });
+        }
       }
       case "ethereum-deploy-contract": {
         const { amount, data, gas_limit } = ledgerAction.payload;
         const value = new BigNumber(amount);
 
-        return this.wallets.ethereum.deployContract(data, value, gas_limit);
+        try {
+          return this.wallets.ethereum.deployContract(data, value, gas_limit);
+        } catch (error) {
+          throw new ChainError(ledgerAction.type, error, {
+            data,
+            value,
+            gas_limit
+          });
+        }
       }
       case "lnd-send-payment": {
         const {
@@ -173,20 +228,32 @@ export class Swap {
           network
         } = ledgerAction.payload;
 
-        await this.wallets.lightning.assertLndDetails(
-          self_public_key,
-          chain,
-          network
-        );
+        try {
+          await this.wallets.lightning.assertLndDetails(
+            self_public_key,
+            chain,
+            network
+          );
 
-        await this.wallets.lightning.sendPayment(
-          to_public_key,
-          amount,
-          secret_hash,
-          final_cltv_delta
-        );
+          await this.wallets.lightning.sendPayment(
+            to_public_key,
+            amount,
+            secret_hash,
+            final_cltv_delta
+          );
 
-        return secret_hash;
+          return secret_hash;
+        } catch (error) {
+          throw new ChainError(ledgerAction.type, error, {
+            self_public_key,
+            to_public_key,
+            amount,
+            secret_hash,
+            final_cltv_delta,
+            chain,
+            network
+          });
+        }
       }
       case "lnd-add-hold-invoice": {
         const {
@@ -199,18 +266,30 @@ export class Swap {
           network
         } = ledgerAction.payload;
 
-        await this.wallets.lightning.assertLndDetails(
-          self_public_key,
-          chain,
-          network
-        );
+        try {
+          await this.wallets.lightning.assertLndDetails(
+            self_public_key,
+            chain,
+            network
+          );
 
-        return this.wallets.lightning.addHoldInvoice(
-          amount,
-          secret_hash,
-          expiry,
-          cltv_expiry
-        );
+          return this.wallets.lightning.addHoldInvoice(
+            amount,
+            secret_hash,
+            expiry,
+            cltv_expiry
+          );
+        } catch (error) {
+          throw new ChainError(ledgerAction.type, error, {
+            self_public_key,
+            amount,
+            secret_hash,
+            expiry,
+            cltv_expiry,
+            chain,
+            network
+          });
+        }
       }
       case "lnd-settle-invoice": {
         const {
@@ -219,16 +298,24 @@ export class Swap {
           chain,
           network
         } = ledgerAction.payload;
+        try {
+          await this.wallets.lightning.assertLndDetails(
+            self_public_key,
+            chain,
+            network
+          );
 
-        await this.wallets.lightning.assertLndDetails(
-          self_public_key,
-          chain,
-          network
-        );
+          await this.wallets.lightning.settleInvoice(secret);
 
-        await this.wallets.lightning.settleInvoice(secret);
-
-        return secret;
+          return secret;
+        } catch (error) {
+          throw new ChainError(ledgerAction.type, error, {
+            self_public_key,
+            secret,
+            chain,
+            network
+          });
+        }
       }
       default:
         throw new Error(`Cannot handle ${ledgerAction.type}`);
@@ -242,6 +329,7 @@ export class Swap {
     while (true) {
       await sleep(tryIntervalSecs * 1000);
 
+      // This may throw if cnd returns an error or there is a network error
       const swap = await this.fetchDetails();
       const actions = swap.actions;
 
@@ -255,6 +343,7 @@ export class Swap {
         continue;
       }
 
+      // This may throw if cnd returns an error or there is a network error
       return this.cnd.executeSirenAction(action!, (field: Field) =>
         this.fieldValueResolver(field)
       );

--- a/src/swap.ts
+++ b/src/swap.ts
@@ -325,7 +325,7 @@ export class Swap {
     while (true) {
       await sleep(tryIntervalSecs * 1000);
 
-      // This may throw if cnd returns an error or there is a network error
+      // This throws if cnd returns an error or there is a network error
       const swap = await this.fetchDetails();
       const actions = swap.actions;
 
@@ -339,10 +339,15 @@ export class Swap {
         continue;
       }
 
-      // This may throw if cnd returns an error or there is a network error
-      return this.cnd.executeSirenAction(action!, (field: Field) =>
-        this.fieldValueResolver(field)
-      );
+      // This throws if cnd returns an error or there is a network error
+      return this.cnd.executeSirenAction(action!, async (field: Field) => {
+        try {
+          // Awaiting here allows us to have better context
+          return await this.fieldValueResolver(field);
+        } catch (error) {
+          throw new ChainError(actionName, error, field);
+        }
+      });
     }
   }
 

--- a/src/swap.ts
+++ b/src/swap.ts
@@ -8,10 +8,10 @@ import { AllWallets, Wallets } from "./wallet";
 export class WalletError extends Error {
   constructor(
     public readonly attemptedAction: string,
-    public readonly callError: Error,
+    public readonly source: Error,
     public readonly callParams: any
   ) {
-    super(callError.message);
+    super(source.message);
   }
 }
 

--- a/src/wallet/lightning.ts
+++ b/src/wallet/lightning.ts
@@ -135,6 +135,14 @@ export class LightningWallet {
     }
   }
 
+  /**
+   * Asserts that the available lnd instance is the same than the one connected to cnd.
+   *
+   * @param selfPublicKey
+   * @param chain
+   * @param network
+   * @throws Error if the lnd instance details mismatch
+   */
   public async assertLndDetails(
     selfPublicKey: string,
     chain: string,


### PR DESCRIPTION
_99% review_

I have selected the following approach for this PR after considering the feedback provided. I decided not to go with tuples as per @yosriady's [suggestion](https://github.com/comit-network/comit-js-sdk/pull/152#issuecomment-595603819) simply because it is a lot of work as I'd need to catch all failures to transform them to Promise resolution. It is also easy to miss. If we miss it would mean that the user end-up with a thrown error when they do not expect one.

We propagate by throwing when any error is encountered.
We try to _intercept_ any error to add more context to them (see `Problem` and `ChainError` classes)

The idea is that the lib consumer can catch those errors and manipulate them easily, as follow:

```
try {
	swap.redeem();
} catch (error) {
	if (error instanceOf ChainError) {
		// do something about the wallet
    } else if (error instanceOf Problem) {
      	// do something about cnd
    } else {
      	// display
	}
}
```

Resolves https://github.com/comit-network/comit-js-sdk/issues/97