### PR TITLE
Integrations fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - `Transaction.transactionId` is now public and renamed to `Transaction.id`.
+- **Breaking API Change**: Correct the type for `alpha_cltv_expiry` & `beta_cltv_expiry`.
+- Mark `address_hint` as optional in cnd Swap Request, as per cnd's API. 
 
 ## [0.14.1] - 2020-03-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Mark `address_hint` as optional in cnd Swap Request, as per cnd's API.
 - Use number chain id instead of string network for Ethereum in lighting routes body request.
 - Nest Alpha and Beta parameters in lighting routes body request.
+- **Breaking API Change**: Rename `SwapTransactionStatus` to `TransactionStatus`.
 
 ## [0.14.1] - 2020-03-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - `Transaction.transactionId` is now public and renamed to `Transaction.id`.
 - **Breaking API Change**: Correct the type for `alpha_cltv_expiry` & `beta_cltv_expiry`.
-- Mark `address_hint` as optional in cnd Swap Request, as per cnd's API. 
+- Mark `address_hint` as optional in cnd Swap Request, as per cnd's API.
+- Use number chain id instead of string network for Ethereum in lighting routes body request.
 
 ## [0.14.1] - 2020-03-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Export interfaces of cnd lightning body requests.
+
 ### Changed
 - `Transaction.transactionId` is now public and renamed to `Transaction.id`.
 - **Breaking API Change**: Correct the type for `alpha_cltv_expiry` & `beta_cltv_expiry`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Breaking API Change**: Correct the type for `alpha_cltv_expiry` & `beta_cltv_expiry`.
 - Mark `address_hint` as optional in cnd Swap Request, as per cnd's API.
 - Use number chain id instead of string network for Ethereum in lighting routes body request.
+- Nest Alpha and Beta parameters in lighting routes body request.
 
 ## [0.14.1] - 2020-03-23
 

--- a/src/cnd/cnd.ts
+++ b/src/cnd/cnd.ts
@@ -81,21 +81,29 @@ interface Ethereum {
   chain_id: number;
 }
 
+export type HanEthereumEtherRequestParams = RequestParams & Han & Ethereum;
+export type HalightLightningBitcoinRequestParams = RequestParams &
+  Halight &
+  Bitcoin;
+export type Herc20EthereumErc20RequestParams = RequestParams &
+  Herc20 &
+  Ethereum;
+
 export type HanEthereumEtherHalightLightningBitcoinRequestBody = CoreRequestBody<
-  RequestParams & Han & Ethereum,
-  RequestParams & Halight & Bitcoin
+  HanEthereumEtherRequestParams,
+  HalightLightningBitcoinRequestParams
 >;
 export type Herc20EthereumErc20HalightLightningBitcoinRequestBody = CoreRequestBody<
-  RequestParams & Herc20 & Ethereum,
-  RequestParams & Bitcoin & Halight
+  Herc20EthereumErc20RequestParams,
+  HalightLightningBitcoinRequestParams
 >;
 export type HalightLightningBitcoinHanEthereumEtherRequestBody = CoreRequestBody<
-  RequestParams & Halight & Bitcoin,
-  RequestParams & Han & Ethereum
+  HalightLightningBitcoinRequestParams,
+  HanEthereumEtherRequestParams
 >;
 export type HalightLightningBitcoinHerc20EthereumErc20RequestBody = CoreRequestBody<
-  RequestParams & Halight & Bitcoin,
-  RequestParams & Herc20 & Ethereum
+  HalightLightningBitcoinRequestParams,
+  Herc20EthereumErc20RequestParams
 >;
 
 export interface BitcoinSendAmountToAddressPayload {

--- a/src/cnd/cnd.ts
+++ b/src/cnd/cnd.ts
@@ -48,7 +48,7 @@ export interface SwapRequest {
   peer: Peer;
 }
 
-export interface CoreRequestBody {
+interface CoreRequestBody {
   alpha_amount: string;
   beta_amount: string;
   alpha_network: string;
@@ -59,44 +59,44 @@ export interface CoreRequestBody {
   peer: Peer;
 }
 
-export interface AlphaHanAdditionalRequestBody {
+interface AlphaHan {
   alpha_absolute_expiry: number;
 }
 
-export interface BetaHanAdditionalRequestBody {
+interface BetaHan {
   beta_absolute_expiry: number;
 }
 
-export interface AlphaHerc20AdditionalRequestBody {
+interface AlphaHerc20 {
   alpha_contract_address: string;
   alpha_absolute_expiry: number;
 }
 
-export interface BetaHerc20AdditionalRequestBody {
+interface BetaHerc20 {
   beta_contract_address: string;
   beta_absolute_expiry: number;
 }
 
-export interface AlphaHalightAdditionalRequestBody {
+interface AlphaHalight {
   alpha_cltv_expiry: number;
 }
 
-export interface BetaHalightAdditionalRequestBody {
+interface BetaHalight {
   beta_cltv_expiry: number;
 }
 
 export type HanEthereumEtherHalightLightningBitcoinRequestBody = CoreRequestBody &
-  AlphaHanAdditionalRequestBody &
-  BetaHalightAdditionalRequestBody;
+  AlphaHan &
+  BetaHalight;
 export type Herc20EthereumErc20HalightLightningBitcoinRequestBody = CoreRequestBody &
-  AlphaHerc20AdditionalRequestBody &
-  BetaHalightAdditionalRequestBody;
+  AlphaHerc20 &
+  BetaHalight;
 export type HalightLightningBitcoinHanEthereumEtherRequestBody = CoreRequestBody &
-  AlphaHalightAdditionalRequestBody &
-  BetaHanAdditionalRequestBody;
+  AlphaHalight &
+  BetaHan;
 export type HalightLightningBitcoinHerc20EthereumErc20RequestBody = CoreRequestBody &
-  AlphaHalightAdditionalRequestBody &
-  BetaHerc20AdditionalRequestBody;
+  AlphaHalight &
+  BetaHerc20;
 
 export interface BitcoinSendAmountToAddressPayload {
   to: string;

--- a/src/cnd/cnd.ts
+++ b/src/cnd/cnd.ts
@@ -28,7 +28,7 @@ export interface Asset {
 
 export interface Peer {
   peer_id: string;
-  address_hint: string;
+  address_hint?: string;
 }
 
 /**

--- a/src/cnd/cnd.ts
+++ b/src/cnd/cnd.ts
@@ -51,8 +51,6 @@ export interface SwapRequest {
 interface CoreRequestBody {
   alpha_amount: string;
   beta_amount: string;
-  alpha_network: string;
-  beta_network: string;
   alpha_identity: string;
   beta_identity: string;
   role: "Alice" | "Bob";
@@ -85,18 +83,42 @@ interface BetaHalight {
   beta_cltv_expiry: number;
 }
 
+interface AlphaBitcoin {
+  alpha_network: string;
+}
+
+interface BetaBitcoin {
+  beta_network: string;
+}
+
+interface AlphaEthereum {
+  alpha_chain_id: number;
+}
+
+interface BetaEthereum {
+  beta_chain_id: number;
+}
+
 export type HanEthereumEtherHalightLightningBitcoinRequestBody = CoreRequestBody &
   AlphaHan &
-  BetaHalight;
+  AlphaEthereum &
+  BetaHalight &
+  BetaBitcoin;
 export type Herc20EthereumErc20HalightLightningBitcoinRequestBody = CoreRequestBody &
   AlphaHerc20 &
+  AlphaEthereum &
+  BetaBitcoin &
   BetaHalight;
 export type HalightLightningBitcoinHanEthereumEtherRequestBody = CoreRequestBody &
   AlphaHalight &
-  BetaHan;
+  AlphaBitcoin &
+  BetaHan &
+  BetaEthereum;
 export type HalightLightningBitcoinHerc20EthereumErc20RequestBody = CoreRequestBody &
   AlphaHalight &
-  BetaHerc20;
+  AlphaBitcoin &
+  BetaHerc20 &
+  BetaEthereum;
 
 export interface BitcoinSendAmountToAddressPayload {
   to: string;

--- a/src/cnd/cnd.ts
+++ b/src/cnd/cnd.ts
@@ -48,77 +48,55 @@ export interface SwapRequest {
   peer: Peer;
 }
 
-interface CoreRequestBody {
-  alpha_amount: string;
-  beta_amount: string;
-  alpha_identity: string;
-  beta_identity: string;
+interface CoreRequestBody<A, B> {
+  alpha: A;
+  beta: B;
   role: "Alice" | "Bob";
   peer: Peer;
 }
 
-interface AlphaHan {
-  alpha_absolute_expiry: number;
+export interface RequestParams {
+  amount: string;
+  identity: string;
 }
 
-interface BetaHan {
-  beta_absolute_expiry: number;
+interface Han {
+  absolute_expiry: number;
 }
 
-interface AlphaHerc20 {
-  alpha_contract_address: string;
-  alpha_absolute_expiry: number;
+interface Herc20 {
+  contract_address: string;
+  absolute_expiry: number;
 }
 
-interface BetaHerc20 {
-  beta_contract_address: string;
-  beta_absolute_expiry: number;
+interface Halight {
+  cltv_expiry: number;
 }
 
-interface AlphaHalight {
-  alpha_cltv_expiry: number;
+interface Bitcoin {
+  network: string;
 }
 
-interface BetaHalight {
-  beta_cltv_expiry: number;
+interface Ethereum {
+  chain_id: number;
 }
 
-interface AlphaBitcoin {
-  alpha_network: string;
-}
-
-interface BetaBitcoin {
-  beta_network: string;
-}
-
-interface AlphaEthereum {
-  alpha_chain_id: number;
-}
-
-interface BetaEthereum {
-  beta_chain_id: number;
-}
-
-export type HanEthereumEtherHalightLightningBitcoinRequestBody = CoreRequestBody &
-  AlphaHan &
-  AlphaEthereum &
-  BetaHalight &
-  BetaBitcoin;
-export type Herc20EthereumErc20HalightLightningBitcoinRequestBody = CoreRequestBody &
-  AlphaHerc20 &
-  AlphaEthereum &
-  BetaBitcoin &
-  BetaHalight;
-export type HalightLightningBitcoinHanEthereumEtherRequestBody = CoreRequestBody &
-  AlphaHalight &
-  AlphaBitcoin &
-  BetaHan &
-  BetaEthereum;
-export type HalightLightningBitcoinHerc20EthereumErc20RequestBody = CoreRequestBody &
-  AlphaHalight &
-  AlphaBitcoin &
-  BetaHerc20 &
-  BetaEthereum;
+export type HanEthereumEtherHalightLightningBitcoinRequestBody = CoreRequestBody<
+  RequestParams & Han & Ethereum,
+  RequestParams & Halight & Bitcoin
+>;
+export type Herc20EthereumErc20HalightLightningBitcoinRequestBody = CoreRequestBody<
+  RequestParams & Herc20 & Ethereum,
+  RequestParams & Bitcoin & Halight
+>;
+export type HalightLightningBitcoinHanEthereumEtherRequestBody = CoreRequestBody<
+  RequestParams & Halight & Bitcoin,
+  RequestParams & Han & Ethereum
+>;
+export type HalightLightningBitcoinHerc20EthereumErc20RequestBody = CoreRequestBody<
+  RequestParams & Halight & Bitcoin,
+  RequestParams & Herc20 & Ethereum
+>;
 
 export interface BitcoinSendAmountToAddressPayload {
   to: string;

--- a/src/cnd/cnd.ts
+++ b/src/cnd/cnd.ts
@@ -78,11 +78,11 @@ export interface BetaHerc20AdditionalRequestBody {
 }
 
 export interface AlphaHalightAdditionalRequestBody {
-  alpha_cltv_expiry: string;
+  alpha_cltv_expiry: number;
 }
 
 export interface BetaHalightAdditionalRequestBody {
-  beta_cltv_expiry: string;
+  beta_cltv_expiry: number;
 }
 
 export type HanEthereumEtherHalightLightningBitcoinRequestBody = CoreRequestBody &

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,11 @@ export {
   EthereumDeployContractPayload,
   Peer,
   SwapRequest,
-  SwapDetails
+  SwapDetails,
+  HalightLightningBitcoinHanEthereumEtherRequestBody,
+  HalightLightningBitcoinHerc20EthereumErc20RequestBody,
+  HanEthereumEtherHalightLightningBitcoinRequestBody,
+  Herc20EthereumErc20HalightLightningBitcoinRequestBody
 } from "./cnd/cnd";
 export { Problem } from "./cnd/axios_rfc7807_middleware";
 export * from "./cnd/siren";

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,10 @@ export {
   HalightLightningBitcoinHanEthereumEtherRequestBody,
   HalightLightningBitcoinHerc20EthereumErc20RequestBody,
   HanEthereumEtherHalightLightningBitcoinRequestBody,
-  Herc20EthereumErc20HalightLightningBitcoinRequestBody
+  Herc20EthereumErc20HalightLightningBitcoinRequestBody,
+  HalightLightningBitcoinRequestParams,
+  HanEthereumEtherRequestParams,
+  Herc20EthereumErc20RequestParams
 } from "./cnd/cnd";
 export { Problem } from "./cnd/axios_rfc7807_middleware";
 export * from "./cnd/siren";

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,7 +21,7 @@ export {
 } from "./cnd/cnd";
 export { Problem } from "./cnd/axios_rfc7807_middleware";
 export * from "./cnd/siren";
-export { Transaction, SwapTransactionStatus } from "./transaction";
+export { Transaction, TransactionStatus } from "./transaction";
 
 export { Actor, createActor } from "./actor";
 

--- a/src/transaction.spec.ts
+++ b/src/transaction.spec.ts
@@ -1,4 +1,4 @@
-import { Transaction, SwapTransactionStatus } from "./transaction";
+import { Transaction, TransactionStatus } from "./transaction";
 import { EthereumWallet } from "./wallet/ethereum";
 
 const defaultEthereumWallet = new EthereumWallet("");
@@ -20,7 +20,7 @@ describe("Transaction", () => {
 
     const status = await swapTransaction.status();
 
-    expect(status).toEqual(SwapTransactionStatus.Failed);
+    expect(status).toEqual(TransactionStatus.Failed);
   });
 
   it("returns pending for an unconfirmed Ethereum transaction", async () => {
@@ -45,7 +45,7 @@ describe("Transaction", () => {
 
     const status = await swapTransaction.status();
 
-    expect(status).toEqual(SwapTransactionStatus.Pending);
+    expect(status).toEqual(TransactionStatus.Pending);
   });
 
   it("returns confirmed for a mined Ethereum transaction", async () => {
@@ -70,6 +70,6 @@ describe("Transaction", () => {
 
     const status = await swapTransaction.status();
 
-    expect(status).toEqual(SwapTransactionStatus.Confirmed);
+    expect(status).toEqual(TransactionStatus.Confirmed);
   });
 });

--- a/src/transaction.ts
+++ b/src/transaction.ts
@@ -1,6 +1,6 @@
 import { EthereumWallet } from "./wallet/ethereum";
 
-export enum SwapTransactionStatus {
+export enum TransactionStatus {
   /**
    * The transaction was rejected by the blockchain node.
    */
@@ -27,21 +27,21 @@ export class Transaction {
   /**
    * @returns The transaction status by asking the blockchain.
    */
-  public async status(): Promise<SwapTransactionStatus> {
+  public async status(): Promise<TransactionStatus> {
     if (!!this.wallet.ethereum) {
       return this.ethereumStatus();
     }
     throw new Error("Wallet was not set");
   }
 
-  private async ethereumStatus(): Promise<SwapTransactionStatus> {
+  private async ethereumStatus(): Promise<TransactionStatus> {
     const wallet = this.ethereumWallet;
     const receipt = await wallet.getTransactionReceipt(this.id);
     if (!receipt) {
       throw new Error(`Could not retrieve receipt for ${this.id} on Ethereum`);
     }
     if (receipt.status === undefined || receipt.status === 0) {
-      return SwapTransactionStatus.Failed;
+      return TransactionStatus.Failed;
     }
     const transaction = await wallet.getTransaction(this.id);
     if (!transaction) {
@@ -50,9 +50,9 @@ export class Transaction {
       );
     }
     if (transaction.confirmations === 0) {
-      return SwapTransactionStatus.Pending;
+      return TransactionStatus.Pending;
     }
-    return SwapTransactionStatus.Confirmed;
+    return TransactionStatus.Confirmed;
   }
 
   private get ethereumWallet(): EthereumWallet {


### PR DESCRIPTION
Few fixes after integration 0.14.1 in comit-rs e2e tests with https://github.com/comit-network/comit-rs/pull/2305.

Redesign of the body request for the lighting routes:
- 7d57d6879a27fed840357244eb1b8e15e110602d: Rename the `*_network` for Ethereum to `chain_id`. This is because for Ethereum it is a `number`. I think using different types (`string` for Bitcoin) with the same name `*_network` is just going to lead to issues.
- f87f48259b2aa98ad231d58e2db736ffc13731d5: Nest Alpha and Beta parameters. After working on this today and yesterday and integrating in the e2e tests (https://github.com/comit-network/comit-rs/pull/2305) I just find the flat structure and repetition of `alpha_` and `beta_` painful. Hence the new proposal.