### PR TITLE
Fix rejection on getting Ethereum transaction status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Do not throw when attempting to retrieve the status of unconfirmed Ethereum transactions.
+
+### Added
+- Added optional parameter to  `Transaction.status()` to allow to wait for a transaction to be confirmed or rejected before returning.
+
 ## [0.15.0] - 2020-03-25
 
 ### Added

--- a/src/transaction.spec.ts
+++ b/src/transaction.spec.ts
@@ -10,6 +10,12 @@ describe("Transaction", () => {
       ""
     );
 
+    defaultEthereumWallet.getTransaction = jest.fn().mockImplementation(() => {
+      return {
+        confirmations: 1
+      };
+    });
+
     defaultEthereumWallet.getTransactionReceipt = jest
       .fn()
       .mockImplementation(() => {
@@ -29,14 +35,6 @@ describe("Transaction", () => {
       ""
     );
 
-    defaultEthereumWallet.getTransactionReceipt = jest
-      .fn()
-      .mockImplementation(() => {
-        return {
-          status: 1
-        };
-      });
-
     defaultEthereumWallet.getTransaction = jest.fn().mockImplementation(() => {
       return {
         confirmations: 0
@@ -54,6 +52,12 @@ describe("Transaction", () => {
       ""
     );
 
+    defaultEthereumWallet.getTransaction = jest.fn().mockImplementation(() => {
+      return {
+        confirmations: 1
+      };
+    });
+
     defaultEthereumWallet.getTransactionReceipt = jest
       .fn()
       .mockImplementation(() => {
@@ -61,12 +65,6 @@ describe("Transaction", () => {
           status: 1
         };
       });
-
-    defaultEthereumWallet.getTransaction = jest.fn().mockImplementation(() => {
-      return {
-        confirmations: 1
-      };
-    });
 
     const status = await swapTransaction.status();
 


### PR DESCRIPTION
Ready for review, usage is in https://github.com/comit-network/comit-rs/pull/2313

A supplementary API could be make `Transaction` an event emitter. At this stage I'd prefer to see the need for it from the PoC before investigating time in it.