### PR TITLE
Replace bcoin wallet with bitcoind wallet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## Added
+- Implemented `BitcoinWallet` using `bitcoind`.
+
+## Deprecated
+- Implementation of `BitcoinWallet` using `bcoin`.
+
 ## [0.15.2] - 2020-03-30
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "@radar/lnrpc": "^0.9.1-beta",
-    "axios": "^0.19.0",
+    "axios": "^0.19.2",
     "bcoin": "https://github.com/bcoin-org/bcoin#2496acc7a98a43f00a7b5728eb256877c1bbf001",
     "bignumber.js": "^9.0.0",
     "bitcoin-core": "^2.2.0",
@@ -28,6 +28,7 @@
     "moment": "^2.24.0",
     "p-event": "^4.1.0",
     "p-timeout": "^3.2.0",
+    "satoshi-bitcoin": "^1.0.4",
     "urijs": "^1.19.2"
   },
   "devDependencies": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,7 +26,12 @@ export { Transaction, TransactionStatus } from "./transaction";
 export { Actor, createActor } from "./actor";
 
 export { AllWallets, Wallets } from "./wallet";
-export { BitcoinWallet, InMemoryBitcoinWallet } from "./wallet/bitcoin";
+export {
+  BitcoinWallet,
+  BitcoindWallet,
+  Network as BitcoinNetwork,
+  BitcoindWalletArgs
+} from "./wallet/bitcoin";
 export { EthereumWallet } from "./wallet/ethereum";
 export { LightningWallet, Outpoint } from "./wallet/lightning";
 

--- a/src/wallet/bitcoin.ts
+++ b/src/wallet/bitcoin.ts
@@ -1,5 +1,7 @@
+import axios, { AxiosInstance, Method } from "axios";
 import { Amount, Chain, Network, Pool, TX, WalletDB } from "bcoin";
 import Logger from "blgr";
+import { toBitcoin } from "satoshi-bitcoin";
 
 /**
  * Interface defining the Bitcoin wallet functionalities needed by the SDK to execute a swap involving Bitcoin.
@@ -15,15 +17,191 @@ export interface BitcoinWallet {
   sendToAddress(
     address: string,
     satoshis: number,
-    network: string
+    network: Network
   ): Promise<string>;
 
   broadcastTransaction(
     transactionHex: string,
-    network: string
+    network: Network
   ): Promise<string>;
 
   getFee(): string;
+}
+
+export interface BitcoindWalletArgs {
+  url: string;
+  username: string;
+  password: string;
+  walletDescriptor: string;
+  walletName: string;
+  rescan?: boolean;
+}
+
+/**
+ * Instance of a bitcoind 0.19.1 wallet.
+ *
+ * This is to be used for demos, examples and dev environment only. No safeguards are applied, no data is written on
+ * the disk. This is not to be used for mainnet, instead, implement your own {@link BitcoinWallet}
+ */
+export class BitcoindWallet implements BitcoinWallet {
+  public static async newInstance({
+    url,
+    username,
+    password,
+    walletDescriptor,
+    walletName,
+    rescan
+  }: BitcoindWalletArgs): Promise<BitcoindWallet> {
+    const auth = { username, password };
+    const client = axios.create({
+      url,
+      method: "post" as Method,
+      auth
+    });
+
+    const walletExists = await client
+      .request({
+        data: {
+          jsonrpc: "1.0",
+          method: "listwallets"
+        }
+      })
+      .then(res => res.data.result.includes(walletName));
+
+    if (!walletExists) {
+      await client.request({
+        data: {
+          jsonrpc: "1.0",
+          method: "createwallet",
+          params: [walletName]
+        }
+      });
+    }
+
+    if (rescan === undefined) {
+      rescan = !walletExists;
+    }
+
+    // Ask bitcoind for a checksum if none was provided with the descriptor
+    if (!hasChecksum(walletDescriptor)) {
+      const checksum = await client
+        .request({
+          data: {
+            jsonrpc: "1.0",
+            method: "getdescriptorinfo",
+            params: [walletDescriptor]
+          }
+        })
+        .then(res => res.data.result.chekcsum);
+      walletDescriptor = `${walletDescriptor}#${checksum}`;
+    }
+
+    const walletClient = axios.create({
+      url: `${url}/wallet/${walletName}`,
+      method: "post" as Method,
+      auth
+    });
+
+    await walletClient.request({
+      data: {
+        jsonrpc: "1.0",
+        method: "importmulti",
+        params: [
+          [{ desc: walletDescriptor, timestamp: 0, range: 0 }],
+          { rescan }
+        ]
+      }
+    });
+
+    return new BitcoindWallet(walletClient);
+  }
+
+  private constructor(private rpcClient: AxiosInstance) {}
+
+  public async getBalance(): Promise<number> {
+    const res = await this.rpcClient.request({
+      data: { jsonrpc: "1.0", method: "getbalance", params: [] }
+    });
+    return res.data.result;
+  }
+
+  public async getAddress(): Promise<string> {
+    const res = await this.rpcClient.request({
+      data: { jsonrpc: "1.0", method: "getnewaddress", params: [] }
+    });
+
+    return res.data.result;
+  }
+
+  public async sendToAddress(
+    address: string,
+    satoshis: number,
+    network: Network
+  ): Promise<string> {
+    await this.assertNetwork(network);
+
+    const res = await this.rpcClient.request({
+      data: {
+        jsonrpc: "1.0",
+        method: "sendtoaddress",
+        params: [address, toBitcoin(satoshis)]
+      }
+    });
+
+    return res.data.result;
+  }
+
+  public async broadcastTransaction(
+    transactionHex: string,
+    network: Network
+  ): Promise<string> {
+    await this.assertNetwork(network);
+
+    const res = await this.rpcClient.request({
+      data: {
+        jsonrpc: "1.0",
+        method: "sendrawtransaction",
+        params: [transactionHex]
+      }
+    });
+
+    return res.data.result;
+  }
+
+  public getFee(): string {
+    // should be dynamic in a real application
+    return "150";
+  }
+
+  public async close(): Promise<void> {
+    await this.rpcClient.request({
+      data: {
+        jsonrpc: "1.0",
+        method: "unloadwallet",
+        params: []
+      }
+    });
+  }
+
+  private async assertNetwork(network: Network): Promise<void> {
+    const res = await this.rpcClient.request({
+      data: { jsonrpc: "1.0", method: "getblockchaininfo", params: [] }
+    });
+
+    if (res.data.result.chain !== network) {
+      return Promise.reject(
+        `This wallet is only connected to the ${network} network and cannot perform actions on the ${network} network`
+      );
+    }
+  }
+}
+
+export type Network = "main" | "test" | "regtest";
+
+function hasChecksum(descriptor: string): boolean {
+  const [, checksum] = descriptor.split("#", 2);
+
+  return !!checksum && checksum.length === 8;
 }
 
 /**
@@ -32,8 +210,17 @@ export interface BitcoinWallet {
  * This is to be used for demos, examples and dev environment only. No safeguards are applied, no data is written on
  * the disk.
  * This is not to be used for mainnet, instead, implement your own {@link BitcoinWallet}
+ *
+ * @deprecated since version 0.15.2.
+ * Will be removed in version 0.16.0.
+ *
+ * Use {@link BitcoindWallet} instead or implement your own {@link BitcoinWallet}.
  */
 export class InMemoryBitcoinWallet implements BitcoinWallet {
+  /**
+   * @deprecated since version 0.15.2.
+   * Will be removed in version 0.16.0.
+   */
   public static async newInstance(
     network: string,
     peerUri: string,
@@ -168,6 +355,10 @@ export class InMemoryBitcoinWallet implements BitcoinWallet {
     return "150";
   }
 
+  /**
+   * @deprecated since version 0.15.2.
+   * Will be removed in version 0.16.0.
+   */
   public async close(): Promise<void> {
     const tasks = [];
     if (this.pool.opened) {

--- a/types/satoshi_bitcoin/index.d.ts
+++ b/types/satoshi_bitcoin/index.d.ts
@@ -1,0 +1,4 @@
+declare module "satoshi-bitcoin" {
+  export function toSatoshi(btc: number | string): number;
+  export function toBitcoin(sat: number | string): number;
+}


### PR DESCRIPTION
Tentatively fixes #177.

- Only after playing around with a little example inside `create-comit-app` (trying to keep the HD key functionality) did I realise that there is a `bitcoin-core` JS library that we use in `comit-rs` to instantiate a Bitcoin RPC client. I still kind of prefer to use `axios`, since we have to maintain our own types to use that other library anyway, but I may be wrong.
- These changes have been tested against a modified branch of `comit-rs`. See comit-network/comit-rs#2446.