### PR TITLE
Stop bors to proceed if the `no-mergify` label is present

### DIFF
--- a/bors.toml
+++ b/bors.toml
@@ -1,2 +1,3 @@
 status = ["build"]
 pr_status = ["license/cla"]
+block_labels = ["no-mergify"]


### PR DESCRIPTION
This is to prevent absence-minded developers to trigger bors even
though they set a no-mergify label in purpose to do some clean up
before merging a pull request.