### PR TITLE
Trigger checks once release PR is created

### DIFF
--- a/.github/workflows/draft-new-release.yml
+++ b/.github/workflows/draft-new-release.yml
@@ -69,3 +69,10 @@ jobs:
             I've updated the changelog and bumped the versions in the manifest files in this commit: ${{ steps.make-commit.outputs.commit }}.
 
             Merging this PR will create a GitHub release and upload any assets that are created as part of the release build.
+      # GitHub Action does not allow recursion so the CI checks are not trigger when the release branch is pushed
+      - name: Trigger CI checks for new pull request
+        uses: peter-evans/repository-dispatch@v1
+        with:
+          token: ${{ secrets.GITHUB_REPO_TOKEN }}
+          even-type: ci-checks
+          client-payload: '{"branch": "release/${{ env.RELEASE_VERSION }}"}'

--- a/.github/workflows/release-pr-ci.yml
+++ b/.github/workflows/release-pr-ci.yml
@@ -1,0 +1,24 @@
+name: Node CI for Release PR
+
+repository_dispatch:
+  types:
+    - ci-checks
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.client_payload.branch }}
+      - name: Use Node.js 10.x
+        uses: actions/setup-node@v1
+        with:
+          node-version: 10.x
+      - name: yarn install and test
+        run: |
+          yarn install
+          yarn list
+          yarn test
+        env:
+          CI: true


### PR DESCRIPTION
GitHub Action does not allow recursion so the
CI checks are not triggers on the release branch
as it is pushed by the "draft new release" action.
So we use repo dispatch to make it happen.