### PR TITLE
Make it easier to find the checks

### DIFF
--- a/.github/workflows/draft-new-release.yml
+++ b/.github/workflows/draft-new-release.yml
@@ -68,6 +68,8 @@ jobs:
             This PR was created in response to this release issue: #${{ github.event.issue.number }}.
             I've updated the changelog and bumped the versions in the manifest files in this commit: ${{ steps.make-commit.outputs.commit }}.
 
+            Checks have been triggered and can be found [here](https://github.com/comit-network/comit-js-sdk/actions?query=workflow%3A%22Node+CI+for+Draft+Release+PR%22).
+
             Merging this PR will create a GitHub release and upload any assets that are created as part of the release build.
       # GitHub Action does not allow recursion so the CI checks are not trigger when the release branch is pushed
       - name: Trigger CI checks for new pull request

--- a/.github/workflows/release-pr-ci.yml
+++ b/.github/workflows/release-pr-ci.yml
@@ -7,11 +7,14 @@ on:
 
 jobs:
   build:
+    strategy:
+      matrix:
+        ref: ["${{ github.event.client_payload.branch }}"]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
         with:
-          ref: ${{ github.event.client_payload.branch }}
+          ref: ${{ matrix.ref }}
       - name: Use Node.js 10.x
         uses: actions/setup-node@v1
         with:


### PR DESCRIPTION
Because the checks are triggered via repo_dispatch
they are not linked to the draft release PR.
Hence, to make it easier to find them, a link is
provided in the body of the PR and the branch
is used in a matrix, allowing it to be present in
the name of the job on GitHub UI.