### PR TITLE
Assert chain_id on actions against Ethereum

### DIFF
--- a/src/cnd/action_payload.ts
+++ b/src/cnd/action_payload.ts
@@ -18,14 +18,14 @@ export interface EthereumDeployContractPayload {
   data: string;
   amount: string;
   gas_limit: string;
-  network: string;
+  chain_id: string;
 }
 
 export interface EthereumCallContractPayload {
   contract_address: string;
   data: string;
   gas_limit: string;
-  network: string;
+  chain_id: string;
 }
 
 export interface LndSendPaymentPayload {

--- a/src/swap.ts
+++ b/src/swap.ts
@@ -193,13 +193,19 @@ export class Swap {
         }
       }
       case "ethereum-call-contract": {
-        const { data, contract_address, gas_limit } = ledgerAction.payload;
+        const {
+          data,
+          contract_address,
+          gas_limit,
+          chain_id
+        } = ledgerAction.payload;
 
         try {
           const transactionId = await this.wallets.ethereum.callContract(
             data,
             contract_address,
-            gas_limit
+            gas_limit,
+            chain_id
           );
           return new Transaction(
             { ethereum: this.wallets.ethereum },
@@ -214,14 +220,15 @@ export class Swap {
         }
       }
       case "ethereum-deploy-contract": {
-        const { amount, data, gas_limit } = ledgerAction.payload;
+        const { amount, data, gas_limit, chain_id } = ledgerAction.payload;
         const value = new BigNumber(amount);
 
         try {
           const transactionId = await this.wallets.ethereum.deployContract(
             data,
             value,
-            gas_limit
+            gas_limit,
+            chain_id
           );
           return new Transaction(
             { ethereum: this.wallets.ethereum },

--- a/src/wallet/ethereum.ts
+++ b/src/wallet/ethereum.ts
@@ -119,7 +119,7 @@ export class EthereumWallet {
 
     if (actualNetwork.chainId !== expectedChainId) {
       return Promise.reject(
-        `This wallet is connected to the chainId with chainId: ${expectedChainId}  and cannot perform actions on against a chainId with ${actualNetwork.chainId} chainId`
+        `This wallet is connected to the chain with chainId: ${expectedChainId}  and cannot perform actions on chain with chainId ${actualNetwork.chainId}`
       );
     }
   }

--- a/src/wallet/ethereum.ts
+++ b/src/wallet/ethereum.ts
@@ -62,8 +62,10 @@ export class EthereumWallet {
   public async deployContract(
     data: string,
     amount: BigNumber,
-    gasLimit: string
+    gasLimit: string,
+    chainId: number
   ): Promise<string> {
+    await this.assertNetwork(chainId);
     const value = new BigNumberEthers(amount.toString());
     const transaction: TransactionRequest = {
       data,
@@ -76,8 +78,10 @@ export class EthereumWallet {
   public async callContract(
     data: string,
     contractAddress: string,
-    gasLimit: string
+    gasLimit: string,
+    chainId: number
   ): Promise<string> {
+    await this.assertNetwork(chainId);
     const transaction: TransactionRequest = {
       data,
       to: contractAddress,
@@ -108,5 +112,15 @@ export class EthereumWallet {
     }
 
     return response.hash;
+  }
+
+  private async assertNetwork(expectedChainId: number): Promise<void> {
+    const actualNetwork = await this.wallet.provider.getNetwork();
+
+    if (actualNetwork.chainId !== expectedChainId) {
+      return Promise.reject(
+        `This wallet is connected to the chainId with chainId: ${expectedChainId}  and cannot perform actions on against a chainId with ${actualNetwork.chainId} chainId`
+      );
+    }
   }
 }


### PR DESCRIPTION
cnd tells us against which network a particular action should be executed.
This is now enforced by the sdk.

Resolves #4 

Does this count as a breaking change? The functions are public but we only use it internally. 