### PR TITLE
Add getAllSwaps function to comit_client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+-  Add new function (`getAllSwaps`) to `ComitClient` which provides the means of retrieving all swaps regardless of their state. 
+
 ## [0.15.6] - 2020-04-27
 
 ### Fixed

--- a/src/comit_client.ts
+++ b/src/comit_client.ts
@@ -95,6 +95,11 @@ export class ComitClient {
       .map(swap => this.newSwap(swap));
   }
 
+  public async getAllSwaps(): Promise<Swap[]> {
+    const swaps = await this.cnd.getSwaps();
+    return swaps.map(swap => this.newSwap(swap));
+  }
+
   public async getOngoingSwaps(): Promise<Swap[]> {
     const swaps = await this.cnd.getSwaps();
     return swaps


### PR DESCRIPTION
Add getAllSwaps function to comit_client so that a dev does not have to fiddle with low-level api of cnd

Resolves #189 