### PR TITLE
Improve error messages generated from problems

### DIFF
--- a/src/cnd/__snapshots__/cnd.spec.ts.snap
+++ b/src/cnd/__snapshots__/cnd.spec.ts.snap
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`should return a Problem if the response is application/problem+json 1`] = `[Error: Request failed with status code 500: Internal Server Error]`;
+
+exports[`should return a Problem if the response is application/problem+json 2`] = `[Error: Request failed with status code 405: Invalid action invocation]`;
+
+exports[`should return a Problem if the response is application/problem+json 3`] = `[Error: Request failed with status code 400: Swap not supported The requested combination of ledgers and assets is not supported.]`;

--- a/src/cnd/axios_rfc7807_middleware.spec.ts
+++ b/src/cnd/axios_rfc7807_middleware.spec.ts
@@ -1,0 +1,49 @@
+import { Problem } from "./axios_rfc7807_middleware";
+
+describe("problem message", () => {
+  it("should format all fields to a descriptive message", () => {
+    const problem = new Problem({
+      title: "Swap not supported.",
+      status: 400,
+      detail: "This combination of protocols is not supported.",
+      type: "https://comit.network/docs/errors/swap-not-supported"
+    });
+
+    expect(problem.message).toMatchInlineSnapshot(
+      `"Request failed with status code 400: Swap not supported. This combination of protocols is not supported. See https://comit.network/docs/errors/swap-not-supported for more information."`
+    );
+  });
+
+  it("should exclude the url if it is not present", () => {
+    const problem = new Problem({
+      title: "Swap not supported.",
+      status: 400,
+      detail: "This combination of protocols is not supported."
+    });
+
+    expect(problem.message).toMatchInlineSnapshot(
+      `"Request failed with status code 400: Swap not supported. This combination of protocols is not supported."`
+    );
+  });
+
+  it("should exclude the statuscode if it is not present", () => {
+    const problem = new Problem({
+      title: "Swap not supported.",
+      detail: "This combination of protocols is not supported."
+    });
+
+    expect(problem.message).toMatchInlineSnapshot(
+      `"Request failed: Swap not supported. This combination of protocols is not supported."`
+    );
+  });
+
+  it("should exclude the detail message if it is not present", () => {
+    const problem = new Problem({
+      title: "Swap not supported."
+    });
+
+    expect(problem.message).toMatchInlineSnapshot(
+      `"Request failed: Swap not supported."`
+    );
+  });
+});

--- a/src/cnd/axios_rfc7807_middleware.ts
+++ b/src/cnd/axios_rfc7807_middleware.ts
@@ -2,6 +2,24 @@ import { AxiosError } from "axios";
 import contentType from "content-type";
 
 export class Problem extends Error {
+  private static makeMessage({
+    title,
+    type,
+    status,
+    detail
+  }: ProblemMembers): string {
+    const statusPart = status
+      ? `Request failed with status code ${status}: `
+      : `Request failed: `;
+    const typePart =
+      type && type !== "about:blank"
+        ? ` See ${type} for more information.`
+        : ``;
+    const detailPart = detail ? ` ${detail}` : ``;
+
+    return `${statusPart}${title}${detailPart}${typePart}`;
+  }
+
   public readonly type: string;
   public readonly title: string;
   public readonly status?: number;
@@ -9,7 +27,7 @@ export class Problem extends Error {
   public readonly instance?: string;
 
   constructor({ title, type, status, detail, instance }: ProblemMembers) {
-    super(title);
+    super(Problem.makeMessage({ title, type, status, detail, instance }));
     this.type = type || "about:blank";
     this.status = status;
     this.detail = detail;

--- a/src/cnd/cnd.spec.ts
+++ b/src/cnd/cnd.spec.ts
@@ -1,5 +1,4 @@
 import nock = require("nock");
-import { Problem } from "./axios_rfc7807_middleware";
 import { Cnd } from "./cnd";
 
 it.each([
@@ -27,14 +26,7 @@ it.each([
 
       const promise = postSwap();
 
-      await expect(promise).rejects.toStrictEqual(
-        new Problem({
-          title: title!,
-          detail: detail!,
-          status: statusCode,
-          type: type!
-        })
-      );
+      await expect(promise).rejects.toMatchSnapshot();
 
       return scope;
     })
@@ -48,8 +40,8 @@ it("should return a generic axios error if the status code is fauly and the cont
 
     const promise = postSwap();
 
-    await expect(promise).rejects.toEqual(
-      new Error("Request failed with status code 400")
+    await expect(promise).rejects.toMatchInlineSnapshot(
+      `[Error: Request failed with status code 400]`
     );
 
     return scope;


### PR DESCRIPTION
While doing https://github.com/comit-network/comit-rs/pull/2554, I realized that the error messages generated by the problems were actually not that great because I was just using the title of the problem.

This patch aims to make the situation better and also adds tests for the messages that are generated.