### PR TITLE
Release 0.16.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+-   New `Swap.nextAction` interface, allows to get and execute the next recommended action returned by cnd 0.8.0 and above.
+
 ## [0.16.0] - 2020-05-05
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.16.1] - 2020-06-02
+
 ### Added
 
 -   New `Swap.nextAction` interface, allows to get and execute the next recommended action returned by cnd 0.8.0 and above.
@@ -276,7 +278,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   Common code that can be used to build applications on top of COMIT.
 
-[Unreleased]: https://github.com/comit-network/comit-js-sdk/compare/0.16.0...HEAD
+[Unreleased]: https://github.com/comit-network/comit-js-sdk/compare/0.16.1...HEAD
+
+[0.16.1]: https://github.com/comit-network/comit-js-sdk/compare/0.15.6...0.16.1
 
 [0.16.0]: https://github.com/comit-network/comit-js-sdk/compare/0.15.6...0.16.0
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comit-sdk",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "description": "An SDK for developing COMIT applications.",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/src/action.spec.ts
+++ b/src/action.spec.ts
@@ -1,0 +1,41 @@
+import { Action } from "./action";
+import { Step, SwapAction } from "./cnd/swaps_payload";
+import { Swap } from "./swap";
+
+const swapAction: SwapAction = { name: Step.Redeem, href: "/redeem" };
+
+describe("Action", () => {
+  it("has the same name than the swap action used to construct", () => {
+    const swap = (undefined as unknown) as Swap;
+    const action = new Action(swapAction, swap);
+
+    expect(action.name).toEqual(swapAction.name);
+  });
+
+  it("calls Swap.executeAction with the parameters of the swap action used to construct", async () => {
+    const mockExecuteAction = jest.fn(async () => {
+      return {};
+    });
+    const mockNextAction = jest.fn(async () => {
+      return swapAction;
+    });
+    const mockDoLedgerAction = jest.fn(async () => {
+      return "";
+    });
+    const swap = ({
+      executeAction: mockExecuteAction,
+      nextAction: mockNextAction,
+      doLedgerAction: mockDoLedgerAction
+    } as unknown) as Swap;
+    const action = new Action(swapAction, swap);
+
+    await action.execute();
+
+    expect(mockExecuteAction.mock.calls.length).toBe(1);
+    // @ts-ignore: mockExecuteAction is expected to be called with one parameter
+    expect(mockExecuteAction.mock.calls[0][0]).toMatchObject({
+      name: "redeem",
+      href: "/redeem"
+    });
+  });
+});

--- a/src/action.ts
+++ b/src/action.ts
@@ -1,0 +1,24 @@
+import { Step, SwapAction } from "./cnd/swaps_payload";
+import { Swap } from "./swap";
+import { Transaction } from "./transaction";
+
+/**
+ * An executable action.
+ */
+export class Action {
+  constructor(private action: SwapAction, private swap: Swap) {}
+
+  get name(): Step {
+    return this.action.name;
+  }
+
+  /**
+   * Execute the action.
+   *
+   * @throws A {@link Problem} from the cnd REST API, or {@link WalletError} if the blockchain wallet throws, or an {@link Error}.
+   */
+  public async execute(): Promise<Transaction | string> {
+    const response = await this.swap.executeAction(this.action);
+    return this.swap.doLedgerAction(response.data);
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -60,3 +60,5 @@ export { MakerNegotiator } from "./negotiation/maker/maker_negotiator";
 export { TakerNegotiator } from "./negotiation/taker/taker_negotiator";
 
 export { Lnd } from "./lnd";
+
+export { Action } from "./action";


### PR DESCRIPTION
Trying to finish the "Recommended Unique Action" Project by resolving https://github.com/comit-network/comit-rs/issues/2753

First attempt was to simply release the current dev branch and integrate the latest release in the e2e tests but it includes [breaking changes](https://github.com/comit-network/comit-js-sdk/pull/240) I am not familiar with.

Second attempt was to bring https://github.com/comit-network/comit-js-sdk/pull/241 changes in the comit-rs e2e test. Unfortunately, this is not possible because `Swap.fieldValueResolver()` is private and the only method available to execute an action is `Swap.executeSirenAction()` which take the name of the action and will retrieve the full content from cnd again.

This is the third attempt, cherry pick the RUA changes and releasing them.