### PR TITLE
Release 0.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,16 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.17.0] - 2020-06-03
+
 ### Added
 
 -   Support for `hbit-herc20` and `herc20-hbit` swaps.
--   New `Swap.nextAction` interface, allows to get and execute the next recommended action returned by cnd 0.8.0 and above. 
+-   New `Swap.nextAction` interface, allows to get and execute the next recommended action returned by cnd 0.8.0 and above.
 
 ### Changed
 
--   **Breaking API Change**: All the `create` routes for creating swaps were reduced to protocol names; ledger and asset were removed from the name. 
+-   **Breaking API Change**: All the `create` routes for creating swaps were reduced to protocol names; ledger and asset were removed from the name.
 -   **Breaking API Change**: All the `*RequestBody`s for creating swaps were reduced to protocol names; ledger and asset were removed from the name.
--   **Breaking API Change**: Siren types are now exported as `siren` to avoid unsuspected name conflicts.  
+-   **Breaking API Change**: Siren types are now exported as `siren` to avoid unsuspected name conflicts.
 
 ### Removed
 
@@ -36,7 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
--   **Breaking API Change**: The promise returned by `LightningWallet.sendPayment` now resolves when the payment is `in flight`, previously resolving when `settled`. 
+-   **Breaking API Change**: The promise returned by `LightningWallet.sendPayment` now resolves when the payment is `in flight`, previously resolving when `settled`.
 
 ## [0.15.6] - 2020-04-27
 
@@ -293,7 +295,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   Common code that can be used to build applications on top of COMIT.
 
-[Unreleased]: https://github.com/comit-network/comit-js-sdk/compare/0.16.1...HEAD
+[Unreleased]: https://github.com/comit-network/comit-js-sdk/compare/0.17.0...HEAD
+
+[0.16.1]: https://github.com/comit-network/comit-js-sdk/compare/0.16.1...0.17.0
 
 [0.16.1]: https://github.com/comit-network/comit-js-sdk/compare/0.15.6...0.16.1
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comit-sdk",
-  "version": "0.16.1",
+  "version": "0.17.0",
   "description": "An SDK for developing COMIT applications.",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",


### PR DESCRIPTION
### Added

-   Support for `hbit-herc20` and `herc20-hbit` swaps.
-   New `Swap.nextAction` interface, allows to get and execute the next recommended action returned by cnd 0.8.0 and above.

### Changed

-   **Breaking API Change**: All the `create` routes for creating swaps were reduced to protocol names; ledger and asset were removed from the name.
-   **Breaking API Change**: All the `*RequestBody`s for creating swaps were reduced to protocol names; ledger and asset were removed from the name.
-   **Breaking API Change**: Siren types are now exported as `siren` to avoid unsuspected name conflicts.

### Removed

-   Remove deprecated `InMemoryBitcoinWallet`.