### PR TITLE
Wait for next message from lnd if channel is not ready

### DIFF
--- a/src/wallet/lightning.ts
+++ b/src/wallet/lightning.ts
@@ -129,9 +129,17 @@ export class LightningWallet {
       );
     });
 
-    const status: OpenStatusUpdate = await pEvent(openChannel, "data");
+    let outpoint;
+    while (!outpoint) {
+      const status: OpenStatusUpdate = await pEvent(openChannel, "data");
+      try {
+        outpoint = outpointFromChannelStatusUpdate(status);
+      } catch (e) {
+        // Let's wait for another update
+      }
+    }
 
-    return outpointFromChannelStatusUpdate(status);
+    return outpoint;
   }
 
   public async sendPaymentWithRequest(
@@ -204,6 +212,7 @@ export interface Outpoint {
 }
 
 function outpointFromChannelStatusUpdate(status: OpenStatusUpdate): Outpoint {
+  console.log(status);
   let txId;
   let vout;
 


### PR DESCRIPTION
Sometimes, lnd returns a `OpenStatusUpdate` that does not contain the outpoint of the channel.

Instead of failing, we wait for the next message.

Hopefully we don't wait forever.

Used in https://github.com/comit-network/comit-rs/pull/3020